### PR TITLE
Cap suite parallelism by available CPU cores

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ const config: SkillGymConfig = {
     outputDir: "./.skillgym-results",
     reporter: "standard",
     schedule: "serial",
+    maxParallel: 4,
     maxSteps: 4,
   },
   defaults: {
@@ -142,6 +143,7 @@ Most important config properties:
 - `run.outputDir`: where artifacts, reports, and preserved workspaces are written
 - `run.reporter`: built-in `standard` reporter or a custom reporter module path
 - `run.schedule`: execution scheduling mode for case x runner pairs
+- `run.maxParallel`: maximum concurrent executions for non-serial schedules, defaulting to available CPU parallelism
 - `run.maxSteps`: best-effort limit on streamed agent steps before skillgym terminates the run
 - `run.workspace`: default workspace mode for the suite
 - `defaults.timeoutMs`: default per-case timeout
@@ -154,10 +156,12 @@ The execution unit is one case x runner pair. `skillgym` expands the suite into 
 `run.schedule` controls execution order:
 
 - `serial`: run every case/runner pair in declaration order
-- `parallel`: start all selected case/runner pairs concurrently
-- `isolated-by-runner`: keep each runner on its own serial queue while different runners may overlap
+- `parallel`: run selected case/runner pairs concurrently, capped by `run.maxParallel`
+- `isolated-by-runner`: keep each runner on its own serial queue while different runners may overlap, capped by `run.maxParallel`
 
-`serial` is the default. `parallel` maximizes overlap across the full matrix. `isolated-by-runner` is a middle ground when you want each runner to stay ordered internally but still allow different runners to overlap.
+`serial` is the default. `parallel` maximizes overlap across the full matrix up to the configured cap. `isolated-by-runner` is a middle ground when you want each runner to stay ordered internally but still allow different runners to overlap.
+
+For concurrent schedules, `run.maxParallel` defaults to `os.availableParallelism()`. This limits how many SkillGym executions are active at once; it does not pin or limit CPU cores used by an individual agent process.
 
 Concurrent schedules do not copy or isolate the workspace by themselves. Overlapping runs may still interact through the same filesystem state and live runner output unless you use isolated workspaces. OpenCode, Codex, and Claude Code runtime state are isolated per run under each artifact directory.
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -24,6 +24,7 @@ Supported in V1:
 - JavaScript assertions only
 - One benchmark metric: success or failure
 - Session telemetry is preserved for debugging
+- Concurrent execution is capped by available host CPU parallelism unless explicitly overridden
 - Best-effort execution limits should still preserve raw artifacts on failure
 - TypeScript implementation
 - Node.js-compatible APIs only

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -9,7 +9,7 @@ Execution, aggregation, and `results.json` writing stay in the runner. Reporters
 ```bash
 skillgym run <suite.ts> --reporter standard
 skillgym run <suite.ts> --reporter ./examples/custom-reporter.ts
-skillgym run <suite.ts> --schedule isolated-by-runner
+skillgym run <suite.ts> --schedule isolated-by-runner --max-parallel 4
 ```
 
 - Omitting `--reporter` uses the built-in `standard` reporter.
@@ -88,7 +88,7 @@ Final result ordering stays stable even in concurrent schedules:
 - `SuiteRunResult.cases` stays in selected case order
 - `CaseResult.runnerResults` stays in selected runner order
 
-`ReporterContext.scheduleMode` exposes the selected schedule so custom reporters can adapt their output.
+`ReporterContext.scheduleMode` exposes the selected schedule and `ReporterContext.maxParallel` exposes the effective execution concurrency so custom reporters can adapt their output.
 
 Top-level execution failures call `onError` before the error is rethrown.
 
@@ -98,7 +98,7 @@ The built-in `standard` reporter is optimized for polished CLI output.
 
 - Interactive TTY mode can show multiple live running entries at once.
 - Non-interactive mode avoids redraws and prints stable lines only.
-- Non-serial schedules print a warning because runs may overlap in the same workspace.
+- Non-serial schedules with concurrency above 1 print a warning because runs may overlap in the same workspace.
 - Every run prints suite metadata, compact per-run token columns (`in`, `out`, `reason`, `cache`, `billable`) when available, a final summary, and failure artifact paths.
 - Full stack traces are not shown by default.
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -120,4 +120,4 @@ Path rules:
 
 - bootstrap commands are not sandboxed outside the workspace
 - copying large templates may increase runtime and disk usage
-- `isolated-by-runner` controls scheduling only, not workspace reuse
+- `isolated-by-runner` and `run.maxParallel` control scheduling only, not workspace reuse

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ async function main(): Promise<void> {
       const reporterOption = parsed.options.reporter;
       const scheduleOption = parsed.options.schedule;
       const configOption = parsed.options.config;
+      const maxParallelOption = parsed.options["max-parallel"];
       const updateSnapshotsOption = parsed.options["update-snapshots"];
       const snapshotsOption = parsed.options.snapshots;
 
@@ -33,6 +34,7 @@ async function main(): Promise<void> {
         runner: typeof runnerOption === "string" ? runnerOption : undefined,
         reporter: typeof reporterOption === "string" ? reporterOption : undefined,
         schedule: typeof scheduleOption === "string" ? scheduleOption : undefined,
+        maxParallel: typeof maxParallelOption === "string" ? maxParallelOption : undefined,
         reporterCwd: process.cwd(),
         configPath: typeof configOption === "string" ? configOption : undefined,
         updateSnapshots: updateSnapshotsOption === true,

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -16,6 +16,7 @@ ${theme.bold("Run Options:")}
   --cwd ${theme.accent("<path>")}           Override the workspace directory for the run
   --output-dir ${theme.accent("<path>")}    Override where run artifacts are written
   --schedule ${theme.accent("<mode>")}      Choose ${theme.light("serial")}, ${theme.light("parallel")}, or ${theme.light("isolated-by-runner")}
+  --max-parallel ${theme.accent("<n>")}     Cap concurrent executions for non-serial schedules
   --case ${theme.accent("<id>")}            Filter the configured suite to one case id
   --runner ${theme.accent("<runner-id>")}   Filter the configured runner set by runner id
   --reporter ${theme.accent("<value>")}     Use ${theme.light("standard")} or override run.reporter from config
@@ -28,6 +29,7 @@ ${theme.bold("Examples:")}
   ${theme.dim("$")} ${theme.light("skillgym run ./examples/basic-suite.ts --case always-passes")}
   ${theme.dim("$")} ${theme.light("skillgym run ./examples/basic-suite.ts --reporter standard")}
   ${theme.dim("$")} ${theme.light("skillgym run ./examples/basic-suite.ts --schedule isolated-by-runner")}
+  ${theme.dim("$")} ${theme.light("skillgym run ./examples/basic-suite.ts --schedule parallel --max-parallel 4")}
   ${theme.dim("$")} ${theme.light("skillgym run ./examples/basic-suite.ts --update-snapshots")}
 `);
 }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -18,6 +18,7 @@ export async function runCommand(options: {
   cwd?: string;
   outputDir?: string;
   schedule?: string;
+  maxParallel?: string;
   caseId?: string;
   runner?: string;
   reporter?: string;
@@ -35,6 +36,7 @@ export async function runCommand(options: {
       cwd: options.cwd,
       outputDir: options.outputDir,
       schedule: options.schedule,
+      maxParallel: options.maxParallel,
     },
     loadedConfig.config,
   );
@@ -69,6 +71,7 @@ export async function runCommand(options: {
     cwd: path.resolve(runOptions.cwd),
     outputDir: runOptions.outputDir,
     schedule: runOptions.schedule,
+    maxParallel: runOptions.maxParallel,
     caseId: options.caseId,
     runner: options.runner,
     config: loadedConfig.config,

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,7 @@ const CONFIG_FILENAMES = [
 ] as const;
 
 const TOP_LEVEL_KEYS = ["run", "defaults", "runners", "snapshots"] as const;
-const RUN_KEYS = ["cwd", "outputDir", "reporter", "schedule", "workspace", "maxSteps"] as const;
+const RUN_KEYS = ["cwd", "outputDir", "reporter", "schedule", "workspace", "maxSteps", "maxParallel"] as const;
 const DEFAULT_KEYS = ["timeoutMs"] as const;
 const RUNNER_KEYS = ["agent"] as const;
 const COMMON_AGENT_KEYS = ["type", "command", "commandArgs", "env", "model"] as const;
@@ -53,6 +53,7 @@ export interface SkillGymConfig {
     schedule?: ScheduleMode;
     workspace?: SuiteWorkspaceConfig;
     maxSteps?: number;
+    maxParallel?: number;
   };
   defaults?: {
     timeoutMs?: number;
@@ -105,19 +106,26 @@ export function resolveRunOptions(
     cwd?: string;
     outputDir?: string;
     schedule?: string;
+    maxParallel?: string;
   },
   config: SkillGymConfig,
 ): {
   cwd: string;
   outputDir?: string;
   schedule: ScheduleMode;
+  maxParallel?: number;
 } {
+  const maxParallel = cliOptions.maxParallel !== undefined
+    ? parseIntegerString(cliOptions.maxParallel, "CLI option --max-parallel", 1)
+    : config.run?.maxParallel;
+
   return {
     cwd: cliOptions.cwd !== undefined ? path.resolve(cliOptions.cwd) : config.run?.cwd ?? process.cwd(),
     outputDir: cliOptions.outputDir !== undefined ? path.resolve(cliOptions.outputDir) : config.run?.outputDir,
     schedule: cliOptions.schedule !== undefined
       ? parseScheduleMode(cliOptions.schedule, "CLI option --schedule")
       : config.run?.schedule ?? "serial",
+    ...(maxParallel === undefined ? {} : { maxParallel }),
   };
 }
 
@@ -204,6 +212,7 @@ function resolveConfigPaths(config: SkillGymConfig, configDir: string): SkillGym
       schedule: config.run.schedule,
       workspace: config.run.workspace === undefined ? undefined : resolveWorkspaceConfigPaths(config.run.workspace, configDir),
       ...(config.run.maxSteps === undefined ? {} : { maxSteps: config.run.maxSteps }),
+      ...(config.run.maxParallel === undefined ? {} : { maxParallel: config.run.maxParallel }),
     },
     defaults: config.defaults === undefined ? undefined : {
       timeoutMs: config.defaults.timeoutMs,
@@ -277,6 +286,7 @@ function parseRunConfig(value: unknown, configPath: string): SkillGymConfig["run
   ensureKnownKeys(record, RUN_KEYS, configPath);
 
   const maxSteps = parseOptionalInteger(record.maxSteps, `${configPath}.maxSteps`, 1);
+  const maxParallel = parseOptionalInteger(record.maxParallel, `${configPath}.maxParallel`, 1);
 
   return {
     cwd: parseOptionalNonEmptyString(record.cwd, `${configPath}.cwd`),
@@ -285,6 +295,7 @@ function parseRunConfig(value: unknown, configPath: string): SkillGymConfig["run
     schedule: parseOptionalScheduleMode(record.schedule, `${configPath}.schedule`),
     workspace: parseOptionalWorkspaceConfig(record.workspace, `${configPath}.workspace`),
     ...(maxSteps === undefined ? {} : { maxSteps }),
+    ...(maxParallel === undefined ? {} : { maxParallel }),
   };
 }
 
@@ -551,6 +562,16 @@ function parseOptionalInteger(
   }
 
   return value;
+}
+
+function parseIntegerString(value: string, configPath: string, minimum: number): number {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < minimum) {
+    throw invalidConfig(configPath, `expected integer >= ${String(minimum)}`);
+  }
+
+  return parsed;
 }
 
 function parseOptionalSnapshotMetric(value: unknown, configPath: string): SnapshotMetric | undefined {

--- a/src/reporters/contract.ts
+++ b/src/reporters/contract.ts
@@ -13,6 +13,7 @@ export interface ReporterContext {
   selectedRunnerCount: number;
   selectedExecutionCount: number;
   scheduleMode: ScheduleMode;
+  maxParallel: number;
   caseFilter?: string;
   runnerFilter?: string;
 }

--- a/src/reporters/standard.ts
+++ b/src/reporters/standard.ts
@@ -87,8 +87,9 @@ export function createStandardReporter(options: StandardReporterOptions = {}): B
       writeLine(`${colors.dim("Cases     ")}${String(event.context.selectedCaseCount)}`, stdout);
       writeLine(`${colors.dim("Runners   ")}${String(event.context.selectedRunnerCount)}`, stdout);
       writeLine(`${colors.dim("Runs      ")}${String(event.context.selectedExecutionCount)}`, stdout);
+      writeLine(`${colors.dim("Parallel  ")}${String(event.context.maxParallel)}`, stdout);
 
-      if (event.context.scheduleMode !== "serial" && event.context.workspaceMode === "shared") {
+      if (event.context.scheduleMode !== "serial" && event.context.maxParallel > 1 && event.context.workspaceMode === "shared") {
         writeLine(
           colors.yellow(`${symbols.warning} Concurrent schedule: ${event.context.scheduleMode} runs may overlap in the same workspace.`),
           stdout,

--- a/src/runner/execute-suite.ts
+++ b/src/runner/execute-suite.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import process from "node:process";
+import os from "node:os";
 import { getCaseExecutionOptions } from "../config.js";
 import type { CaseResult, RunnerResult, RunnerSummary, SuiteRunResult } from "../domain/result.js";
 import type { ResolvedRunner, RunnerConfig, RunnerInfo } from "../domain/runner.js";
@@ -40,6 +41,7 @@ export async function executeSuite(
     cwd: string;
     outputDir?: string;
     schedule?: ScheduleMode;
+    maxParallel?: number;
     caseId?: string;
     runner?: string;
     config: {
@@ -64,6 +66,7 @@ export async function executeSuite(
   const resolvedSuitePath = path.resolve(suitePath);
   const outputDir = path.resolve(options.outputDir ?? ".skillgym-results", timestampDirName());
   const scheduleMode = options.schedule ?? "serial";
+  const maxParallel = resolveMaxParallel(scheduleMode, options.maxParallel);
   await ensureDir(outputDir);
   const selectedRunners = selectRunners(options.config.runners, options.runner);
   const resolvedWorkspace = resolveEffectiveWorkspace({
@@ -89,6 +92,7 @@ export async function executeSuite(
         selectedCases,
         selectedRunners,
         scheduleMode,
+        maxParallel,
         workspaceMode: resolvedWorkspace.mode,
         caseFilter: options.caseId,
         runnerFilter: options.runner,
@@ -109,6 +113,7 @@ export async function executeSuite(
         selectedCases,
         selectedRunners,
         scheduleMode,
+        maxParallel,
         workspaceMode: resolvedWorkspace.mode,
         caseFilter: options.caseId,
         runnerFilter: options.runner,
@@ -126,6 +131,7 @@ export async function executeSuite(
     selectedCases,
     selectedRunners,
     scheduleMode,
+    maxParallel,
     workspaceMode: resolvedWorkspace.mode,
     caseFilter: options.caseId,
     runnerFilter: options.runner,
@@ -145,7 +151,7 @@ export async function executeSuite(
       startedAt,
     });
 
-    await scheduleExecutions(plannedExecutions, scheduleMode, async ({ item }) => {
+    await scheduleExecutions(plannedExecutions, scheduleMode, maxParallel, async ({ item }) => {
       const state = caseStates[item.caseIndex];
 
       if (state === undefined) {
@@ -395,6 +401,7 @@ function createReporterContext(options: {
   selectedCases: TestCase[];
   selectedRunners: ResolvedRunner[];
   scheduleMode: ScheduleMode;
+  maxParallel: number;
   caseFilter?: string;
   runnerFilter?: string;
   isInteractive?: boolean;
@@ -409,9 +416,18 @@ function createReporterContext(options: {
     selectedRunnerCount: options.selectedRunners.length,
     selectedExecutionCount: options.selectedCases.length * options.selectedRunners.length,
     scheduleMode: options.scheduleMode,
+    maxParallel: options.maxParallel,
     caseFilter: options.caseFilter,
     runnerFilter: options.runnerFilter,
   };
+}
+
+function resolveMaxParallel(scheduleMode: ScheduleMode, configuredMaxParallel: number | undefined): number {
+  if (scheduleMode === "serial") {
+    return 1;
+  }
+
+  return Math.max(1, configuredMaxParallel ?? os.availableParallelism());
 }
 
 function sanitizePathSegment(value: string): string {

--- a/src/runner/scheduler.ts
+++ b/src/runner/scheduler.ts
@@ -8,6 +8,7 @@ export interface PlannedExecution<TItem = unknown> {
 export async function scheduleExecutions<TItem>(
   executions: PlannedExecution<TItem>[],
   scheduleMode: ScheduleMode,
+  maxParallel: number,
   execute: (execution: PlannedExecution<TItem>) => Promise<void>,
 ): Promise<void> {
   switch (scheduleMode) {
@@ -17,18 +18,45 @@ export async function scheduleExecutions<TItem>(
       }
       return;
     case "parallel":
-      await Promise.all(executions.map((execution) => execute(execution)));
+      await runWithConcurrencyLimit(executions, maxParallel, execute);
       return;
     case "isolated-by-runner": {
       const groups = groupByRunner(executions);
-      await Promise.all(groups.map(async (group) => {
+      await runWithConcurrencyLimit(groups, maxParallel, async (group) => {
         for (const execution of group) {
           await execute(execution);
         }
-      }));
+      });
       return;
     }
   }
+}
+
+async function runWithConcurrencyLimit<TItem>(
+  items: TItem[],
+  maxParallel: number,
+  run: (item: TItem) => Promise<void>,
+): Promise<void> {
+  if (items.length === 0) {
+    return;
+  }
+
+  const workerCount = Math.min(maxParallel, items.length);
+  let nextIndex = 0;
+
+  await Promise.all(Array.from({ length: workerCount }, async () => {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+
+      const item = items[index];
+      if (item === undefined) {
+        return;
+      }
+
+      await run(item);
+    }
+  }));
 }
 
 function groupByRunner<TItem>(executions: PlannedExecution<TItem>[]): PlannedExecution<TItem>[][] {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -38,6 +38,7 @@ test("cli help prints full MOTD banner and help sections", async () => {
   expect(result.stdout).toContain("Commands:");
   expect(result.stdout).toContain("Run Options:");
   expect(result.stdout).toContain("--schedule <mode>");
+  expect(result.stdout).toContain("--max-parallel <n>");
   expect(result.stdout).toContain("Examples:");
 });
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -27,7 +27,7 @@ describe("config", () => {
       path.join(tempDir, "bench", "skillgym.config.mjs"),
         [
           "export default {",
-          "  run: { cwd: './workspace', outputDir: './results', reporter: './reporters/custom.ts', schedule: 'serial', workspace: { mode: 'isolated', templateDir: './fixtures/base', bootstrap: { command: './scripts/bootstrap.sh', args: ['--flag'], timeoutMs: 5000 } } },",
+          "  run: { cwd: './workspace', outputDir: './results', reporter: './reporters/custom.ts', schedule: 'serial', maxParallel: 3, workspace: { mode: 'isolated', templateDir: './fixtures/base', bootstrap: { command: './scripts/bootstrap.sh', args: ['--flag'], timeoutMs: 5000 } } },",
           "  defaults: { timeoutMs: 45000 },",
           "  runners: {",
           "    codexMain: { agent: { type: 'codex', command: './bin/codex', commandArgs: ['./scripts/wrapper.ts'], model: 'gpt-5' } }",
@@ -47,6 +47,7 @@ describe("config", () => {
         outputDir: path.join(tempDir, "bench", "results"),
         reporter: path.join(tempDir, "bench", "reporters", "custom.ts"),
         schedule: "serial",
+        maxParallel: 3,
         workspace: {
           mode: "isolated",
           templateDir: path.join(tempDir, "bench", "fixtures", "base"),
@@ -192,6 +193,15 @@ describe("config", () => {
     expect(parsed.run?.maxSteps).toBe(3);
   });
 
+  test("parses run maxParallel", () => {
+    const parsed = parseConfig({
+      run: { maxParallel: 3 },
+      runners: { open: { agent: { type: "opencode", model: "openai/gpt-5" } } },
+    });
+
+    expect(parsed.run?.maxParallel).toBe(3);
+  });
+
   test("accepts cursor-agent runner configs", () => {
     const parsed = parseConfig({
       runners: {
@@ -236,6 +246,7 @@ describe("config", () => {
           cwd: path.join(tempDir, "config-workspace"),
           outputDir: path.join(tempDir, "config-results"),
           schedule: "parallel",
+          maxParallel: 2,
         },
         runners: {
           open: { agent: { type: "opencode", model: "openai/gpt-5" } },
@@ -247,7 +258,20 @@ describe("config", () => {
       cwd: path.join(tempDir, "cli-workspace"),
       outputDir: path.join(tempDir, "config-results"),
       schedule: "parallel",
+      maxParallel: 2,
     });
+  });
+
+  test("run options let CLI maxParallel override config", () => {
+    expect(resolveRunOptions(
+      { maxParallel: "4" },
+      { run: { maxParallel: 2 }, runners: { open: { agent: { type: "opencode", model: "openai/gpt-5" } } } },
+    )).toMatchObject({ maxParallel: 4 });
+
+    expect(() => resolveRunOptions(
+      { maxParallel: "0" },
+      { runners: { open: { agent: { type: "opencode", model: "openai/gpt-5" } } } },
+    )).toThrow("Invalid config at CLI option --max-parallel: expected integer >= 1");
   });
 
   test("run options let CLI schedule override config and default to serial", () => {

--- a/test/reporters/standard.test.ts
+++ b/test/reporters/standard.test.ts
@@ -35,6 +35,7 @@ test("standard reporter prints runner-grouped results and failure artifacts", as
     selectedRunnerCount: 2,
     selectedExecutionCount: 4,
     scheduleMode: "serial" as const,
+    maxParallel: 1,
   };
   const suiteResult: SuiteRunResult = {
     suitePath: context.suitePath,
@@ -87,6 +88,7 @@ test("standard reporter prints runner-grouped results and failure artifacts", as
   expect(output).toContain("Suite     examples/basic-suite.ts");
   expect(output).toContain("Runners   2");
   expect(output).toContain("Runs      4");
+  expect(output).toContain("Parallel  1");
   expect(output).toContain("Runner: open-main");
   expect(output).toContain("Runner: code-main");
   expect(output).toContain("case                       time           tokens in / out / reason / cache / billable");
@@ -134,6 +136,7 @@ test("standard reporter interactive mode renders queued, running, and finished r
     selectedRunnerCount: 2,
     selectedExecutionCount: 4,
     scheduleMode: "parallel" as const,
+    maxParallel: 4,
   };
 
   const openRunner = createRunnerInfo("open-main", { type: "opencode", model: "openai/gpt-5" });
@@ -209,7 +212,7 @@ test("standard reporter interactive mode renders queued, running, and finished r
   expect(finishedOutput).toContain("\u001b[2K");
 });
 
-test("standard reporter prints warning line for non-serial schedules only", async () => {
+test("standard reporter prints warning line for overlapping shared-workspace schedules", async () => {
   const parallelWrites: string[] = [];
   const serialWrites: string[] = [];
   const parallelReporter = createStandardReporter({
@@ -249,6 +252,7 @@ test("standard reporter prints warning line for non-serial schedules only", asyn
       selectedRunnerCount: 1,
       selectedExecutionCount: 1,
       scheduleMode: "parallel",
+      maxParallel: 2,
     },
     cases: [],
     runners: [runner],
@@ -265,6 +269,7 @@ test("standard reporter prints warning line for non-serial schedules only", asyn
       selectedRunnerCount: 1,
       selectedExecutionCount: 1,
       scheduleMode: "serial",
+      maxParallel: 1,
     },
     cases: [],
     runners: [runner],
@@ -301,6 +306,7 @@ test("standard reporter prints friendly runner crash message with log path", asy
     selectedRunnerCount: 1,
     selectedExecutionCount: 1,
     scheduleMode: "serial" as const,
+    maxParallel: 1,
   };
   const suiteResult: SuiteRunResult = {
     suitePath: context.suitePath,
@@ -378,6 +384,7 @@ test("standard reporter points workspace bootstrap failures to bootstrap logs", 
     selectedRunnerCount: 1,
     selectedExecutionCount: 1,
     scheduleMode: "serial" as const,
+    maxParallel: 1,
   };
   const suiteResult: SuiteRunResult = {
     suitePath: context.suitePath,
@@ -459,6 +466,7 @@ test("standard reporter renders max-steps failures with a clear message", async 
     selectedRunnerCount: 1,
     selectedExecutionCount: 1,
     scheduleMode: "serial" as const,
+    maxParallel: 1,
   };
   const suiteResult: SuiteRunResult = {
     suitePath: context.suitePath,
@@ -537,6 +545,7 @@ test("standard reporter suppresses shared-workspace warning for isolated mode", 
       selectedRunnerCount: 1,
       selectedExecutionCount: 1,
       scheduleMode: "parallel",
+      maxParallel: 2,
     },
     cases: [],
     runners: [createRunnerInfo("open-main", { type: "opencode", model: "openai/gpt-5" })],

--- a/test/runner/execute-suite.reporter.test.ts
+++ b/test/runner/execute-suite.reporter.test.ts
@@ -164,6 +164,71 @@ test("executeSuite with parallel schedule keeps final ordering stable while hook
   expect(result.cases[1]?.runnerResults.map((runnerResult) => runnerResult.runner.id)).toEqual(["open", "code"]);
 });
 
+test("executeSuite with parallel schedule respects maxParallel", async () => {
+  const outputDir = await createTempDir();
+  const pending = new Map<string, Deferred<void>>();
+  let active = 0;
+  let maxActive = 0;
+
+  const suitePromise = executeSuite("./suite.ts", [
+    { id: "alpha", prompt: "a", assert() {} },
+    { id: "beta", prompt: "b", assert() {} },
+  ], {
+    cwd: outputDir,
+    outputDir,
+    schedule: "parallel",
+    maxParallel: 2,
+    isInteractive: false,
+    config: {
+      runners: {
+        open: { agent: { type: "opencode", model: "openai/gpt-5" } },
+        code: { agent: { type: "codex", model: "gpt-5" } },
+      },
+    },
+    executeRunnerFn: async (testCase, runner, _adapter, options) => {
+      const key = `${testCase.id}:${runner.id}`;
+      const deferred = createDeferred<void>();
+      pending.set(key, deferred);
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+
+      try {
+        await deferred.promise;
+        return createRunnerResult({
+          caseId: testCase.id,
+          runner,
+          passed: true,
+          durationMs: 10,
+          artifactDir: options.artifactDir,
+          totalTokens: 100,
+          outputTokens: 20,
+          reasoningTokens: 2,
+          observedReads: 1,
+        });
+      } finally {
+        active -= 1;
+      }
+    },
+  });
+
+  await waitFor(() => pending.size === 2);
+  expect(maxActive).toBe(2);
+
+  pending.get("alpha:open")?.resolve();
+  await waitFor(() => pending.size === 3);
+  expect(maxActive).toBe(2);
+
+  for (const deferred of pending.values()) {
+    deferred.resolve();
+  }
+
+  await waitFor(() => pending.size === 4);
+  pending.get("beta:code")?.resolve();
+
+  await suitePromise;
+  expect(maxActive).toBe(2);
+});
+
 test("executeSuite with isolated-by-runner runs serially within a runner and concurrently across runners", async () => {
   const outputDir = await createTempDir();
   const started: string[] = [];
@@ -233,6 +298,70 @@ test("executeSuite with isolated-by-runner runs serially within a runner and con
   expect(result.cases.map((caseResult) => caseResult.caseId)).toEqual(["alpha", "beta"]);
   expect(result.cases[0]?.runnerResults.map((runnerResult) => runnerResult.runner.id)).toEqual(["open", "code"]);
   expect(result.cases[1]?.runnerResults.map((runnerResult) => runnerResult.runner.id)).toEqual(["open", "code"]);
+});
+
+test("executeSuite with isolated-by-runner caps active runner lanes", async () => {
+  const outputDir = await createTempDir();
+  const started: string[] = [];
+  const pending = new Map<string, Deferred<void>>();
+
+  const suitePromise = executeSuite("./suite.ts", [
+    { id: "alpha", prompt: "a", assert() {} },
+    { id: "beta", prompt: "b", assert() {} },
+  ], {
+    cwd: outputDir,
+    outputDir,
+    schedule: "isolated-by-runner",
+    maxParallel: 2,
+    isInteractive: false,
+    config: {
+      runners: {
+        open: { agent: { type: "opencode", model: "openai/gpt-5" } },
+        code: { agent: { type: "codex", model: "gpt-5" } },
+        cursor: { agent: { type: "cursor-agent", model: "composer-2-fast" } },
+      },
+    },
+    executeRunnerFn: async (testCase, runner, _adapter, options) => {
+      const key = `${testCase.id}:${runner.id}`;
+      started.push(key);
+
+      const shouldBlock = key === "alpha:open" || key === "beta:open" || key === "alpha:code";
+      if (shouldBlock) {
+        const deferred = createDeferred<void>();
+        pending.set(key, deferred);
+        await deferred.promise;
+      }
+
+      return createRunnerResult({
+        caseId: testCase.id,
+        runner,
+        passed: true,
+        durationMs: 10,
+        artifactDir: options.artifactDir,
+        totalTokens: 100,
+        outputTokens: 20,
+        reasoningTokens: 2,
+        observedReads: 1,
+      });
+    },
+  });
+
+  await waitFor(() => started.length === 2);
+  expect(started).toEqual(expect.arrayContaining(["alpha:open", "alpha:code"]));
+  expect(started).not.toContain("alpha:cursor");
+
+  pending.get("alpha:open")?.resolve();
+  await waitFor(() => started.includes("beta:open"));
+  expect(started).not.toContain("alpha:cursor");
+
+  pending.get("beta:open")?.resolve();
+  await waitFor(() => started.includes("alpha:cursor"));
+
+  for (const deferred of pending.values()) {
+    deferred.resolve();
+  }
+
+  await suitePromise;
 });
 
 test("executeSuite reports runner execution errors as failed runs", async () => {


### PR DESCRIPTION
## Summary
Cap SkillGym's concurrent suite executions so parallel schedules do not oversubscribe the host by default.

## Context
This adds a `run.maxParallel` config option and `--max-parallel` CLI override for non-serial schedules. When no explicit cap is provided, concurrent schedules use the host's available CPU parallelism. The existing schedule modes keep their intent: `parallel` limits the total active executions, while `isolated-by-runner` limits active runner lanes and still runs each runner lane serially.

The standard reporter now prints the effective parallelism at run start so benchmark logs capture the scheduling environment. Documentation and CLI help were updated to describe the new cap and clarify that this limits SkillGym execution concurrency, not CPU affinity for individual agent processes.

Fixes https://github.com/callstackincubator/skillgym/issues/2

## Proposed Testing Scenario
Run a suite with multiple cases and runners using `--schedule parallel --max-parallel 2` and verify no more than two executions run at once. Then run the same suite with `--schedule isolated-by-runner --max-parallel 2` and verify only two runner lanes are active while each runner's cases remain ordered.