### PR TITLE
Add built-in JSON and GitHub Actions reporters

### DIFF
--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -9,13 +9,14 @@ Execution, aggregation, and `results.json` writing stay in the runner. Reporters
 ```bash
 skillgym run <suite.ts> --reporter standard
 skillgym run <suite.ts> --reporter json
+skillgym run <suite.ts> --reporter json-summary
 skillgym run <suite.ts> --reporter github-actions
 skillgym run <suite.ts> --reporter ./examples/custom-reporter.ts
 skillgym run <suite.ts> --schedule isolated-by-runner
 ```
 
 - Omitting `--reporter` uses the built-in `standard` reporter.
-- Built-in reporters are `standard`, `json`, and `github-actions`.
+- Built-in reporters are `standard`, `json`, `json-summary`, and `github-actions`.
 - Relative paths resolve from `process.cwd()`.
 
 ## Config
@@ -122,11 +123,22 @@ The built-in `json` reporter only writes the final aggregated `SuiteRunResult` J
 - It does not change the `results.json` artifact written by the runner.
 - It is useful for CI steps that want machine-readable stdout.
 
+## JSON summary reporter
+
+The built-in `json-summary` reporter writes a trimmed JSON summary to stdout — smaller than the full `json` reporter output and optimized for LLM consumption.
+
+- It ignores live progress hooks.
+- The output includes per-case and per-runner results with token usage, pass/fail status, artifact paths, and error details, but omits the full session events and raw artifacts.
+- It is useful for post-run analysis steps or feeding results to an LLM.
+
 ## GitHub Actions reporter
 
 The built-in `github-actions` reporter is designed for GitHub CI.
 
-- Failed runs emit workflow command annotations.
-- When `GITHUB_STEP_SUMMARY` is set, the reporter appends a compact Markdown summary for the job.
+- Failed runs emit `::error` workflow command annotations, including file and line when a stack frame is available.
+- When `GITHUB_STEP_SUMMARY` is set, the reporter appends a Markdown job summary containing:
+  - Suite metadata (path, case/run counts, duration, output dir)
+  - A per-runner section with a table of all cases (pass/fail status, duration, and token columns: input, output, reasoning, cache, billable)
+  - A failures section listing up to 10 failures with error name/message, artifact dir, and log path
 - When `GITHUB_STEP_SUMMARY` is missing, summary writing is skipped.
 - PR comments stay out of scope for the reporter itself; add those in a separate CI step if needed.

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -8,12 +8,14 @@ Execution, aggregation, and `results.json` writing stay in the runner. Reporters
 
 ```bash
 skillgym run <suite.ts> --reporter standard
+skillgym run <suite.ts> --reporter json
+skillgym run <suite.ts> --reporter github-actions
 skillgym run <suite.ts> --reporter ./examples/custom-reporter.ts
 skillgym run <suite.ts> --schedule isolated-by-runner
 ```
 
 - Omitting `--reporter` uses the built-in `standard` reporter.
-- `standard` explicitly selects the built-in reporter.
+- Built-in reporters are `standard`, `json`, and `github-actions`.
 - Relative paths resolve from `process.cwd()`.
 
 ## Config
@@ -111,3 +113,20 @@ Reporter-visible token metrics on `RunnerSummary` include:
 - `averageTotalTokens`
 
 `averageTotalTokens` is shown as `billable` and uses normalized non-cached totals so different runner providers stay comparable.
+
+## JSON reporter
+
+The built-in `json` reporter only writes the final aggregated `SuiteRunResult` JSON to stdout.
+
+- It ignores live progress hooks.
+- It does not change the `results.json` artifact written by the runner.
+- It is useful for CI steps that want machine-readable stdout.
+
+## GitHub Actions reporter
+
+The built-in `github-actions` reporter is designed for GitHub CI.
+
+- Failed runs emit workflow command annotations.
+- When `GITHUB_STEP_SUMMARY` is set, the reporter appends a compact Markdown summary for the job.
+- When `GITHUB_STEP_SUMMARY` is missing, summary writing is skipped.
+- PR comments stay out of scope for the reporter itself; add those in a separate CI step if needed.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,6 @@ async function main(): Promise<void> {
 
   switch (parsed.command) {
     case "run": {
-      printBanner({ kind: "compact" });
       const suitePath = parsed.positionals[0];
       if (suitePath === undefined) {
         throw new Error("Missing suite path. Usage: skillgym run <suite.ts>");

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -18,7 +18,7 @@ ${theme.bold("Run Options:")}
   --schedule ${theme.accent("<mode>")}      Choose ${theme.light("serial")}, ${theme.light("parallel")}, or ${theme.light("isolated-by-runner")}
   --case ${theme.accent("<id>")}            Filter the configured suite to one case id
   --runner ${theme.accent("<runner-id>")}   Filter the configured runner set by runner id
-  --reporter ${theme.accent("<value>")}     Use ${theme.light("standard")} or override run.reporter from config
+  --reporter ${theme.accent("<value>")}     Use ${theme.light("standard")}, ${theme.light("json")}, ${theme.light("github-actions")}, or override run.reporter
   --snapshots ${theme.accent("<path>")}     Override the configured snapshot file path
   --update-snapshots       Refresh snapshot baselines for the executed runs
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { RunnerConfig } from "./domain/runner.js";
 import type { SuiteWorkspaceConfig, WorkspaceBootstrapConfig } from "./domain/test-case.js";
 import { SCHEDULE_MODES, type ScheduleMode } from "./domain/schedule.js";
+import { isBuiltInReporter } from "./reporters/builtins.js";
 import { importFromPath } from "./utils/import.js";
 
 const CONFIG_FILENAMES = [
@@ -252,7 +253,7 @@ function resolvePathLikeValue(value: string, configDir: string): string {
 }
 
 function resolveReporterSpecifier(value: string, configDir: string): string {
-  if (value === "standard" || path.isAbsolute(value)) {
+  if (isBuiltInReporter(value) || path.isAbsolute(value)) {
     return value;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export type {
   SuiteStartEvent,
 } from "./reporters/index.js";
 export { assert } from "./assertions/index.js";
-export { createStandardReporter, loadReporter } from "./reporters/index.js";
+export { BUILT_IN_REPORTER_NAMES, createGitHubActionsReporter, createJsonReporter, createStandardReporter, loadReporter } from "./reporters/index.js";
 export type {
   AssertionOptions,
   CommandAssertions,

--- a/src/reporters/builtins.ts
+++ b/src/reporters/builtins.ts
@@ -1,4 +1,4 @@
-export const BUILT_IN_REPORTER_NAMES = ["standard", "json", "github-actions"] as const;
+export const BUILT_IN_REPORTER_NAMES = ["standard", "json", "json-summary", "github-actions"] as const;
 
 export type BuiltInReporterName = typeof BUILT_IN_REPORTER_NAMES[number];
 

--- a/src/reporters/builtins.ts
+++ b/src/reporters/builtins.ts
@@ -1,0 +1,7 @@
+export const BUILT_IN_REPORTER_NAMES = ["standard", "json", "github-actions"] as const;
+
+export type BuiltInReporterName = typeof BUILT_IN_REPORTER_NAMES[number];
+
+export function isBuiltInReporter(value: string): value is BuiltInReporterName {
+  return BUILT_IN_REPORTER_NAMES.includes(value as BuiltInReporterName);
+}

--- a/src/reporters/github-actions.ts
+++ b/src/reporters/github-actions.ts
@@ -2,7 +2,7 @@ import { appendFile } from "node:fs/promises";
 import process from "node:process";
 import type { CaseResult, RunnerResult, RunnerSummary, SuiteRunResult } from "../domain/result.js";
 import type { BenchmarkReporter } from "./contract.js";
-import { formatDuration } from "./format.js";
+import { formatDuration, formatTokens } from "./format.js";
 import { extractUserStackFrame } from "./stack-frame.js";
 
 const MAX_SUMMARY_FAILURES = 10;
@@ -102,11 +102,17 @@ function formatJobSummary(result: SuiteRunResult): string {
     `- Runs: ${passedRuns} passed, ${totalRuns - passedRuns} failed`,
     `- Duration: ${formatDuration(result.durationMs)}`,
     `- Output: \`${result.outputDir}\``,
-    "",
-    "| Runner | Cases | Avg duration | Avg billable tokens |",
-    "| --- | ---: | ---: | ---: |",
-    ...result.runners.map(formatRunnerSummaryRow),
   ];
+
+  for (const summary of result.runners) {
+    lines.push("", `### Runner: \`${summary.runner.id}\` ${formatRunnerAgentLabel(summary.runner)}`);
+    lines.push("");
+    lines.push("| Case | Duration | Input | Output | Reasoning | Cache | Billable |");
+    lines.push("| --- | ---: | ---: | ---: | ---: | ---: | ---: |");
+    for (const { caseId, runnerResult } of getRunnerCases(result, summary.runner.id)) {
+      lines.push(formatRunnerCaseRow(caseId, runnerResult));
+    }
+  }
 
   if (failures.length > 0) {
     lines.push("", "### Failures");
@@ -122,8 +128,25 @@ function formatJobSummary(result: SuiteRunResult): string {
   return lines.join("\n");
 }
 
-function formatRunnerSummaryRow(summary: RunnerSummary): string {
-  return `| \`${summary.runner.id}\` | ${summary.passedCases}/${summary.totalCases} | ${formatDuration(summary.averageDurationMs)} | ${summary.averageTotalTokens === undefined ? "-" : String(summary.averageTotalTokens)} |`;
+function formatRunnerAgentLabel(runner: RunnerSummary["runner"]): string {
+  const model = runner.agent.model === undefined ? "" : `, ${runner.agent.model}`;
+  return `(${runner.agent.type}${model})`;
+}
+
+function formatRunnerCaseRow(caseId: string, result: RunnerResult): string {
+  const status = result.passed ? "✅" : "❌";
+  const usage = result.report.usage;
+  return `| ${status} \`${caseId}\` | ${formatDuration(result.durationMs)} | ${formatTokens(usage.inputTokens)} | ${formatTokens(usage.outputTokens)} | ${formatTokens(usage.reasoningTokens)} | ${formatTokens(usage.cacheTokens)} | ${formatTokens(usage.totalTokens)} |`;
+}
+
+function getRunnerCases(
+  result: SuiteRunResult,
+  runnerId: string,
+): Array<{ caseId: string; runnerResult: RunnerResult }> {
+  return result.cases.flatMap((caseResult) => {
+    const runnerResult = caseResult.runnerResults.find((entry) => entry.runner.id === runnerId);
+    return runnerResult === undefined ? [] : [{ caseId: caseResult.caseId, runnerResult }];
+  });
 }
 
 function formatFailureSummaryItem(caseId: string, result: RunnerResult): string {

--- a/src/reporters/github-actions.ts
+++ b/src/reporters/github-actions.ts
@@ -1,0 +1,171 @@
+import { appendFile } from "node:fs/promises";
+import process from "node:process";
+import type { CaseResult, RunnerResult, RunnerSummary, SuiteRunResult } from "../domain/result.js";
+import type { BenchmarkReporter } from "./contract.js";
+import { formatDuration } from "./format.js";
+import { extractUserStackFrame } from "./stack-frame.js";
+
+const MAX_SUMMARY_FAILURES = 10;
+
+interface GitHubActionsReporterOptions {
+  stdout?: Pick<NodeJS.WriteStream, "write">;
+  env?: NodeJS.ProcessEnv;
+}
+
+export function createGitHubActionsReporter(options: GitHubActionsReporterOptions = {}): BenchmarkReporter {
+  const stdout = options.stdout ?? process.stdout;
+  const env = options.env ?? process.env;
+
+  return {
+    async onSuiteFinish(event) {
+      for (const failure of listFailures(event.result)) {
+        stdout.write(`${formatAnnotationCommand(failure.caseId, failure.result)}\n`);
+      }
+
+      const summaryPath = env.GITHUB_STEP_SUMMARY;
+      if (summaryPath === undefined || summaryPath.length === 0) {
+        return;
+      }
+
+      await appendFile(summaryPath, `${formatJobSummary(event.result)}\n`, "utf8");
+    },
+  };
+}
+
+function formatAnnotationCommand(caseId: string, result: RunnerResult): string {
+  const properties = new Map<string, string>([["title", `${caseId} > ${result.runner.id}`]]);
+  const stackFrame = result.error === undefined ? undefined : extractUserStackFrame(result.error);
+
+  if (stackFrame !== undefined) {
+    properties.set("file", stackFrame.filePath);
+    properties.set("line", stackFrame.line);
+    properties.set("col", stackFrame.column);
+  }
+
+  return `::error${formatCommandProperties(properties)}::${escapeCommandMessage(formatAnnotationMessage(result))}`;
+}
+
+function formatAnnotationMessage(result: RunnerResult): string {
+  const lines = [`failure type: ${result.failureType ?? "unknown"}`];
+
+  if (result.failureOrigin !== undefined) {
+    lines.push(`failure origin: ${result.failureOrigin}`);
+  }
+
+  if (result.error !== undefined) {
+    lines.push(`error: ${result.error.name}: ${result.error.message}`);
+  }
+
+  lines.push(`artifacts: ${result.artifactDir}`);
+
+  if (result.failureLogPath !== undefined) {
+    lines.push(`log: ${result.failureLogPath}`);
+  }
+
+  return lines.join("\n");
+}
+
+function formatCommandProperties(properties: Map<string, string>): string {
+  if (properties.size === 0) {
+    return "";
+  }
+
+  return ` ${Array.from(properties.entries()).map(([key, value]) => `${key}=${escapeCommandProperty(value)}`).join(",")}`;
+}
+
+function escapeCommandProperty(value: string): string {
+  return value
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A")
+    .replace(/:/g, "%3A")
+    .replace(/,/g, "%2C");
+}
+
+function escapeCommandMessage(value: string): string {
+  return value
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A");
+}
+
+function formatJobSummary(result: SuiteRunResult): string {
+  const passedCases = countPassedCases(result.cases);
+  const passedRuns = countPassedRuns(result.cases);
+  const totalRuns = countTotalRuns(result.cases);
+  const failures = listFailures(result);
+  const lines = [
+    "## SkillGym Summary",
+    "",
+    `- Suite: \`${result.suitePath}\``,
+    `- Cases: ${passedCases} passed, ${result.cases.length - passedCases} failed`,
+    `- Runs: ${passedRuns} passed, ${totalRuns - passedRuns} failed`,
+    `- Duration: ${formatDuration(result.durationMs)}`,
+    `- Output: \`${result.outputDir}\``,
+    "",
+    "| Runner | Cases | Avg duration | Avg billable tokens |",
+    "| --- | ---: | ---: | ---: |",
+    ...result.runners.map(formatRunnerSummaryRow),
+  ];
+
+  if (failures.length > 0) {
+    lines.push("", "### Failures");
+    for (const failure of failures.slice(0, MAX_SUMMARY_FAILURES)) {
+      lines.push(`- ${formatFailureSummaryItem(failure.caseId, failure.result)}`);
+    }
+
+    if (failures.length > MAX_SUMMARY_FAILURES) {
+      lines.push(`- ...and ${failures.length - MAX_SUMMARY_FAILURES} more failures`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatRunnerSummaryRow(summary: RunnerSummary): string {
+  return `| \`${summary.runner.id}\` | ${summary.passedCases}/${summary.totalCases} | ${formatDuration(summary.averageDurationMs)} | ${summary.averageTotalTokens === undefined ? "-" : String(summary.averageTotalTokens)} |`;
+}
+
+function formatFailureSummaryItem(caseId: string, result: RunnerResult): string {
+  const segments = [
+    `\`${caseId} > ${result.runner.id}\``,
+    `${result.failureType ?? "unknown"}`,
+    `artifacts: \`${result.artifactDir}\``,
+  ];
+
+  if (result.failureLogPath !== undefined) {
+    segments.push(`log: \`${result.failureLogPath}\``);
+  }
+
+  if (result.error !== undefined) {
+    segments.splice(2, 0, `${result.error.name}: ${result.error.message}`);
+  }
+
+  return segments.join("; ");
+}
+
+function listFailures(result: SuiteRunResult): Array<{ caseId: string; result: RunnerResult }> {
+  const failures: Array<{ caseId: string; result: RunnerResult }> = [];
+
+  for (const caseResult of result.cases) {
+    for (const runnerResult of caseResult.runnerResults) {
+      if (!runnerResult.passed) {
+        failures.push({ caseId: caseResult.caseId, result: runnerResult });
+      }
+    }
+  }
+
+  return failures;
+}
+
+function countPassedCases(cases: CaseResult[]): number {
+  return cases.filter((caseResult) => caseResult.passed).length;
+}
+
+function countPassedRuns(cases: CaseResult[]): number {
+  return cases.reduce((sum, caseResult) => sum + caseResult.runnerResults.filter((result) => result.passed).length, 0);
+}
+
+function countTotalRuns(cases: CaseResult[]): number {
+  return cases.reduce((sum, caseResult) => sum + caseResult.runnerResults.length, 0);
+}

--- a/src/reporters/index.ts
+++ b/src/reporters/index.ts
@@ -12,5 +12,6 @@ export type {
 export { BUILT_IN_REPORTER_NAMES } from "./builtins.js";
 export { createGitHubActionsReporter } from "./github-actions.js";
 export { createJsonReporter } from "./json.js";
+export { createJsonSummaryReporter } from "./json-summary.js";
 export { loadReporter } from "./load-reporter.js";
 export { createStandardReporter } from "./standard.js";

--- a/src/reporters/index.ts
+++ b/src/reporters/index.ts
@@ -9,5 +9,8 @@ export type {
   SuiteFinishEvent,
   SuiteStartEvent,
 } from "./contract.js";
+export { BUILT_IN_REPORTER_NAMES } from "./builtins.js";
+export { createGitHubActionsReporter } from "./github-actions.js";
+export { createJsonReporter } from "./json.js";
 export { loadReporter } from "./load-reporter.js";
 export { createStandardReporter } from "./standard.js";

--- a/src/reporters/json-summary.ts
+++ b/src/reporters/json-summary.ts
@@ -1,0 +1,93 @@
+import process from "node:process";
+import type { CaseResult, RunnerResult, SuiteRunResult } from "../domain/result.js";
+import type { BenchmarkReporter } from "./contract.js";
+
+interface JsonSummaryReporterOptions {
+  stdout?: Pick<NodeJS.WriteStream, "write">;
+}
+
+interface SummaryError {
+  name: string;
+  message: string;
+}
+
+interface SummaryRunnerResult {
+  runner: RunnerResult["runner"];
+  passed: boolean;
+  durationMs: number;
+  artifactDir: string;
+  usage: RunnerResult["report"]["usage"];
+  error?: SummaryError;
+  failureType?: RunnerResult["failureType"];
+  failureOrigin?: RunnerResult["failureOrigin"];
+}
+
+interface SummaryCaseResult {
+  caseId: string;
+  passed: boolean;
+  runnerResults: SummaryRunnerResult[];
+}
+
+interface SummarySuiteResult {
+  suitePath: string;
+  startedAt: string;
+  endedAt: string;
+  durationMs: number;
+  outputDir: string;
+  cases: SummaryCaseResult[];
+  runners: SuiteRunResult["runners"];
+}
+
+function summarizeRunnerResult(result: RunnerResult): SummaryRunnerResult {
+  const summary: SummaryRunnerResult = {
+    runner: result.runner,
+    passed: result.passed,
+    durationMs: result.durationMs,
+    artifactDir: result.artifactDir,
+    usage: result.report.usage,
+  };
+
+  if (result.error !== undefined) {
+    summary.error = { name: result.error.name, message: result.error.message };
+  }
+
+  if (result.failureType !== undefined) {
+    summary.failureType = result.failureType;
+  }
+
+  if (result.failureOrigin !== undefined) {
+    summary.failureOrigin = result.failureOrigin;
+  }
+
+  return summary;
+}
+
+function summarizeCaseResult(result: CaseResult): SummaryCaseResult {
+  return {
+    caseId: result.caseId,
+    passed: result.passed,
+    runnerResults: result.runnerResults.map(summarizeRunnerResult),
+  };
+}
+
+function summarizeSuiteResult(result: SuiteRunResult): SummarySuiteResult {
+  return {
+    suitePath: result.suitePath,
+    startedAt: result.startedAt,
+    endedAt: result.endedAt,
+    durationMs: result.durationMs,
+    outputDir: result.outputDir,
+    cases: result.cases.map(summarizeCaseResult),
+    runners: result.runners,
+  };
+}
+
+export function createJsonSummaryReporter(options: JsonSummaryReporterOptions = {}): BenchmarkReporter {
+  const stdout = options.stdout ?? process.stdout;
+
+  return {
+    onSuiteFinish(event) {
+      stdout.write(`${JSON.stringify(summarizeSuiteResult(event.result), null, 2)}\n`);
+    },
+  };
+}

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -1,0 +1,16 @@
+import process from "node:process";
+import type { BenchmarkReporter } from "./contract.js";
+
+interface JsonReporterOptions {
+  stdout?: Pick<NodeJS.WriteStream, "write">;
+}
+
+export function createJsonReporter(options: JsonReporterOptions = {}): BenchmarkReporter {
+  const stdout = options.stdout ?? process.stdout;
+
+  return {
+    onSuiteFinish(event) {
+      stdout.write(`${JSON.stringify(event.result, null, 2)}\n`);
+    },
+  };
+}

--- a/src/reporters/load-reporter.ts
+++ b/src/reporters/load-reporter.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import type { BenchmarkReporter } from "./contract.js";
 import { createGitHubActionsReporter } from "./github-actions.js";
 import { createJsonReporter } from "./json.js";
+import { createJsonSummaryReporter } from "./json-summary.js";
 import { createStandardReporter } from "./standard.js";
 import { isBuiltInReporter } from "./builtins.js";
 import { importFromPath } from "../utils/import.js";
@@ -32,6 +33,8 @@ export async function loadReporter(specifier: string | undefined, cwd: string): 
         return createStandardReporter();
       case "json":
         return createJsonReporter();
+      case "json-summary":
+        return createJsonSummaryReporter();
       case "github-actions":
         return createGitHubActionsReporter();
     }

--- a/src/reporters/load-reporter.ts
+++ b/src/reporters/load-reporter.ts
@@ -1,6 +1,9 @@
 import path from "node:path";
 import type { BenchmarkReporter } from "./contract.js";
+import { createGitHubActionsReporter } from "./github-actions.js";
+import { createJsonReporter } from "./json.js";
 import { createStandardReporter } from "./standard.js";
+import { isBuiltInReporter } from "./builtins.js";
 import { importFromPath } from "../utils/import.js";
 
 const reporterHooks = new Set([
@@ -19,8 +22,19 @@ interface ImportedReporterModule {
 }
 
 export async function loadReporter(specifier: string | undefined, cwd: string): Promise<BenchmarkReporter> {
-  if (specifier === undefined || specifier === "standard") {
+  if (specifier === undefined) {
     return createStandardReporter();
+  }
+
+  if (isBuiltInReporter(specifier)) {
+    switch (specifier) {
+      case "standard":
+        return createStandardReporter();
+      case "json":
+        return createJsonReporter();
+      case "github-actions":
+        return createGitHubActionsReporter();
+    }
   }
 
   const resolvedPath = path.resolve(cwd, specifier);

--- a/src/reporters/stack-frame.ts
+++ b/src/reporters/stack-frame.ts
@@ -34,16 +34,23 @@ export function formatStackFrameLocation(location: StackFrameLocation): string {
 
 function parseStackFrame(frame: string): StackFrameLocation | undefined {
   const trimmed = frame.trim().replace(/^at\s+/, "");
-  const match = /\(?(.+):(\d+):(\d+)\)?$/.exec(trimmed);
-  if (match === null) {
-    return undefined;
-  }
 
-  let [, filePath, line, column] = match;
-  if (filePath === undefined || line === undefined || column === undefined) {
-    return undefined;
-  }
+  // Strip optional trailing ")" from frames like "funcName (file:line:col)"
+  const stripped = trimmed.endsWith(")") ? trimmed.slice(0, -1) : trimmed;
 
+  const lastColon = stripped.lastIndexOf(":");
+  if (lastColon === -1) return undefined;
+  const column = stripped.slice(lastColon + 1);
+  if (!/^\d+$/.test(column)) return undefined;
+
+  const secondLastColon = stripped.lastIndexOf(":", lastColon - 1);
+  if (secondLastColon === -1) return undefined;
+  const line = stripped.slice(secondLastColon + 1, lastColon);
+  if (!/^\d+$/.test(line)) return undefined;
+
+  let filePath = stripped.slice(0, secondLastColon);
+
+  // Handle "funcName (file:line:col)" format — extract path after the last "("
   const openParenIndex = filePath.lastIndexOf("(");
   if (openParenIndex !== -1) {
     filePath = filePath.slice(openParenIndex + 1);

--- a/src/reporters/stack-frame.ts
+++ b/src/reporters/stack-frame.ts
@@ -1,0 +1,62 @@
+import type { SerializedError } from "../domain/result.js";
+
+export interface StackFrameLocation {
+  filePath: string;
+  line: string;
+  column: string;
+}
+
+export function extractUserStackFrame(error: SerializedError): StackFrameLocation | undefined {
+  if (error.stack === undefined) {
+    return undefined;
+  }
+
+  const frames = error.stack.split("\n").slice(1);
+  for (const frame of frames) {
+    const parsed = parseStackFrame(frame);
+    if (parsed === undefined) {
+      continue;
+    }
+
+    if (isInternalStackFrame(parsed.filePath)) {
+      continue;
+    }
+
+    return parsed;
+  }
+
+  return undefined;
+}
+
+export function formatStackFrameLocation(location: StackFrameLocation): string {
+  return `${location.filePath}:${location.line}:${location.column}`;
+}
+
+function parseStackFrame(frame: string): StackFrameLocation | undefined {
+  const trimmed = frame.trim().replace(/^at\s+/, "");
+  const match = /\(?(.+):(\d+):(\d+)\)?$/.exec(trimmed);
+  if (match === null) {
+    return undefined;
+  }
+
+  let [, filePath, line, column] = match;
+  if (filePath === undefined || line === undefined || column === undefined) {
+    return undefined;
+  }
+
+  const openParenIndex = filePath.lastIndexOf("(");
+  if (openParenIndex !== -1) {
+    filePath = filePath.slice(openParenIndex + 1);
+  }
+
+  return { filePath, line, column };
+}
+
+function isInternalStackFrame(filePath: string): boolean {
+  return filePath.startsWith("node:")
+    || filePath.includes("/node:internal/")
+    || filePath.includes("/src/assertions/")
+    || filePath.includes("/src/runner/")
+    || filePath.includes("/src/reporters/")
+    || filePath.includes("/node_modules/");
+}

--- a/src/reporters/standard.ts
+++ b/src/reporters/standard.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import process from "node:process";
 import cliSpinners from "cli-spinners";
+import { printBanner } from "../cli/branding.js";
 import pc from "picocolors";
 import type {
   CaseResult,
@@ -82,6 +83,7 @@ export function createStandardReporter(options: StandardReporterOptions = {}): B
 
   return {
     onSuiteStart(event) {
+      printBanner({ kind: "compact", stdout });
       writeLine(`${colors.dim("Suite     ")}${accent(event.context.suitePath)}`, stdout);
       writeLine(`${colors.dim("Workspace ")}${colors.bold(event.context.workspaceMode === "shared" ? event.context.cwd : `${event.context.workspaceMode} per run`)}`, stdout);
       writeLine(`${colors.dim("Output    ")}${colors.bold(event.context.outputDir)}`, stdout);

--- a/src/reporters/standard.ts
+++ b/src/reporters/standard.ts
@@ -21,6 +21,7 @@ import {
   padCell,
   visibleWidth,
 } from "./format.js";
+import { extractUserStackFrame, formatStackFrameLocation } from "./stack-frame.js";
 
 interface FailureEntry {
   caseId: string;
@@ -289,54 +290,8 @@ function formatFailureBlock(
 }
 
 function formatErrorLocation(error: SerializedError): string | undefined {
-  if (error.stack === undefined) {
-    return undefined;
-  }
-
-  const frames = error.stack.split("\n").slice(1);
-  for (const frame of frames) {
-    const parsed = parseStackFrame(frame);
-    if (parsed === undefined) {
-      continue;
-    }
-
-    if (isInternalStackFrame(parsed.filePath)) {
-      continue;
-    }
-
-    return `${parsed.filePath}:${parsed.line}:${parsed.column}`;
-  }
-
-  return undefined;
-}
-
-function parseStackFrame(frame: string): { filePath: string; line: string; column: string } | undefined {
-  const trimmed = frame.trim().replace(/^at\s+/, "");
-  const match = /\(?(.+):(\d+):(\d+)\)?$/.exec(trimmed);
-  if (match === null) {
-    return undefined;
-  }
-
-  let [, filePath, line, column] = match;
-  if (filePath === undefined || line === undefined || column === undefined) {
-    return undefined;
-  }
-
-  const openParenIndex = filePath.lastIndexOf("(");
-  if (openParenIndex !== -1) {
-    filePath = filePath.slice(openParenIndex + 1);
-  }
-
-  return { filePath, line, column };
-}
-
-function isInternalStackFrame(filePath: string): boolean {
-  return filePath.startsWith("node:")
-    || filePath.includes("/node:internal/")
-    || filePath.includes("/src/assertions/")
-    || filePath.includes("/src/runner/")
-    || filePath.includes("/src/reporters/")
-    || filePath.includes("/node_modules/");
+  const location = extractUserStackFrame(error);
+  return location === undefined ? undefined : formatStackFrameLocation(location);
 }
 
 function formatCrashMessage(failure: FailureEntry): string {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -41,15 +41,11 @@ test("cli help prints full MOTD banner and help sections", async () => {
   expect(result.stdout).toContain("Examples:");
 });
 
-test("cli run prints compact banner before reporting missing suite path", async () => {
+test("cli run reports missing suite path without printing MOTD banner", async () => {
   const result = await execCli(["run"]);
 
   expect(result.exitCode).toBe(1);
-  expect(result.stdout).toContain("skillgym");
-  expect(result.stdout).toContain("Prove your agent skills work before you ship them.");
-  expect(result.stdout).not.toContain("by Callstack");
-  expect(result.stdout).not.toContain("Run a benchmark suite");
-  expect(result.stdout).not.toContain("skillgym help");
+  expect(result.stdout).toBe("");
   expect(result.stderr).toContain("Error: missing suite path");
   expect(result.stderr).toContain("`skillgym run` needs a suite file to execute.");
   expect(result.stderr).toContain("skillgym run ./examples/basic-suite.ts");

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -291,6 +291,26 @@ describe("config", () => {
     });
   });
 
+  test("built-in reporter config values stay unresolved", async () => {
+    const configDir = path.join(tempDir, "bench");
+    const suitePath = path.join(configDir, "suite.ts");
+    const configPath = path.join(configDir, "skillgym.config.mjs");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(suitePath, "export default []\n", "utf8");
+    await writeFile(
+      configPath,
+      "export default { run: { reporter: 'github-actions' }, runners: { open: { agent: { type: 'opencode', model: 'openai/gpt-5' } } } };\n",
+      "utf8",
+    );
+
+    const loaded = await loadConfig({ suitePath, configPath });
+
+    expect(resolveReporterOptions({}, loaded)).toEqual({
+      reporter: "github-actions",
+      cwd: configDir,
+    });
+  });
+
   test("executeSuite applies per-case timeout over config defaults and runs every case against selected runners", async () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const outputDir = path.join(tempDir, "results");

--- a/test/reporters/github-actions.test.ts
+++ b/test/reporters/github-actions.test.ts
@@ -1,0 +1,177 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "vitest";
+import type { RunnerInfo, RunnerResult, RunnerSummary, SuiteRunResult } from "../../src/index.js";
+import { createGitHubActionsReporter } from "../../src/reporters/github-actions.js";
+import { createRunnerInfo } from "../../src/runner/runner-info.js";
+import { createSessionReport } from "../helpers/session-report.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((tempDir) => rm(tempDir, { recursive: true, force: true })));
+});
+
+test("github-actions reporter formats escaped annotations for failed runs", async () => {
+  const writes: string[] = [];
+  const runner = createRunnerInfo("code:main", { type: "codex", model: "gpt-5.4" });
+  const reporter = createGitHubActionsReporter({
+    stdout: {
+      write(chunk: string) {
+        writes.push(chunk);
+        return true;
+      },
+    },
+    env: {},
+  });
+
+  await reporter.onSuiteFinish?.({ context: createContext(), result: createSuiteResult({ runner, caseId: "case,a", errorMessage: "boom,\n100%" }) });
+
+  expect(writes.join("")).toContain("::error title=case%2Ca > code%3Amain,file=/workspace/examples/basic-suite.ts,line=14,col=15::");
+  expect(writes.join("")).toContain("failure type: assertion%0Afailure origin: assertion%0Aerror: AssertionError: boom,%0A100%25");
+  expect(writes.join("")).toContain("artifacts: .skillgym-results/run-1/case,a/code-main");
+});
+
+test("github-actions reporter includes file metadata from user stack frames", async () => {
+  const writes: string[] = [];
+  const runner = createRunnerInfo("open-main", { type: "opencode", model: "openai/gpt-5" });
+  const reporter = createGitHubActionsReporter({
+    stdout: {
+      write(chunk: string) {
+        writes.push(chunk);
+        return true;
+      },
+    },
+    env: {},
+  });
+
+  await reporter.onSuiteFinish?.({ context: createContext(), result: createSuiteResult({ runner, caseId: "case-a" }) });
+
+  expect(writes.join("")).toContain("file=/workspace/examples/basic-suite.ts,line=14,col=15");
+});
+
+test("github-actions reporter writes a job summary when GITHUB_STEP_SUMMARY is set", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "skillgym-gha-"));
+  tempDirs.push(tempDir);
+  const summaryPath = path.join(tempDir, "summary.md");
+  const runner = createRunnerInfo("open-main", { type: "opencode", model: "openai/gpt-5" });
+  const reporter = createGitHubActionsReporter({
+    stdout: { write() { return true; } },
+    env: { GITHUB_STEP_SUMMARY: summaryPath },
+  });
+
+  await reporter.onSuiteFinish?.({ context: createContext(), result: createSuiteResult({ runner, caseId: "case-a" }) });
+
+  const summary = await readFile(summaryPath, "utf8");
+  expect(summary).toContain("## SkillGym Summary");
+  expect(summary).toContain("- Suite: `examples/basic-suite.ts`");
+  expect(summary).toContain("- Cases: 0 passed, 1 failed");
+  expect(summary).toContain("- Runs: 0 passed, 1 failed");
+  expect(summary).toContain("| `open-main` | 0/1 | 24s | 12000 |");
+  expect(summary).toContain("- `case-a > open-main`; assertion; AssertionError: expected skill to be loaded before command execution; artifacts: `.skillgym-results/run-1/case-a/open-main`; log: `.skillgym-results/run-1/case-a/open-main/stderr.log`");
+});
+
+test("github-actions reporter skips job summary writes when GITHUB_STEP_SUMMARY is absent", async () => {
+  const writes: string[] = [];
+  const runner = createRunnerInfo("open-main", { type: "opencode", model: "openai/gpt-5" });
+  const reporter = createGitHubActionsReporter({
+    stdout: {
+      write(chunk: string) {
+        writes.push(chunk);
+        return true;
+      },
+    },
+    env: {},
+  });
+
+  await expect(reporter.onSuiteFinish?.({ context: createContext(), result: createSuiteResult({ runner, caseId: "case-a" }) })).resolves.toBeUndefined();
+  expect(writes.join("")).toContain("::error");
+});
+
+function createContext() {
+  return {
+    isInteractive: false,
+    cwd: "/workspace",
+    workspaceMode: "shared" as const,
+    suitePath: "examples/basic-suite.ts",
+    outputDir: ".skillgym-results/run-1",
+    selectedCaseCount: 1,
+    selectedRunnerCount: 1,
+    selectedExecutionCount: 1,
+    scheduleMode: "serial" as const,
+  };
+}
+
+function createSuiteResult(options: { runner: RunnerInfo; caseId: string; errorMessage?: string }): SuiteRunResult {
+  const runnerResult = createFailedRunnerResult(options.runner, options.caseId, options.errorMessage);
+
+  return {
+    suitePath: "examples/basic-suite.ts",
+    startedAt: "2026-04-02T12:00:00.000Z",
+    endedAt: "2026-04-02T12:01:00.000Z",
+    durationMs: 60_000,
+    outputDir: ".skillgym-results/run-1",
+    cases: [{ caseId: options.caseId, passed: false, runnerResults: [runnerResult] }],
+    runners: [createRunnerSummary(options.runner)],
+  };
+}
+
+function createFailedRunnerResult(runner: RunnerInfo, caseId: string, errorMessage = "expected skill to be loaded before command execution"): RunnerResult {
+  return {
+    runner,
+    passed: false,
+    durationMs: 24_800,
+    artifactDir: `.skillgym-results/run-1/${caseId}/${runner.id.replace(/[:]/g, "-")}`,
+    error: {
+      name: "AssertionError",
+      message: errorMessage,
+      stack: [
+        `AssertionError: ${errorMessage}`,
+        "    at assert (/workspace/src/assertions/output.ts:88:10)",
+        "    at Object.assert (/workspace/examples/basic-suite.ts:14:15)",
+        "    at executeRunner (/workspace/src/runner/execute-runner.ts:91:7)",
+      ].join("\n"),
+    },
+    failureType: "assertion",
+    failureOrigin: "assertion",
+    failureLogPath: `.skillgym-results/run-1/${caseId}/${runner.id.replace(/[:]/g, "-")}/stderr.log`,
+    report: createSessionReport({
+      runner,
+      usage: {
+        cacheTokens: 0,
+        totalTokens: 12_000,
+        inputTokens: 9_830,
+        outputTokens: 1_104,
+        reasoningTokens: 0,
+        inputChars: 10,
+        outputChars: 5,
+        reasoningChars: 0,
+        source: {
+          input: "provider",
+          output: "provider",
+          reasoning: "provider",
+        },
+      },
+      files: {
+        observedReads: ["a"],
+        observedSkillReads: [],
+      },
+    }),
+  };
+}
+
+function createRunnerSummary(runner: RunnerInfo): RunnerSummary {
+  return {
+    runner,
+    totalCases: 1,
+    passedCases: 0,
+    successRate: 0,
+    averageDurationMs: 24_800,
+    averageInputTokens: 9_830,
+    averageOutputTokens: 1_104,
+    averageReasoningTokens: 0,
+    averageCacheTokens: 0,
+    averageTotalTokens: 12_000,
+  };
+}

--- a/test/reporters/json-summary.test.ts
+++ b/test/reporters/json-summary.test.ts
@@ -1,0 +1,210 @@
+import { expect, test } from "vitest";
+import type { SuiteRunResult } from "../../src/index.js";
+import { createJsonSummaryReporter } from "../../src/reporters/json-summary.js";
+import { createRunnerInfo } from "../../src/runner/runner-info.js";
+
+test("json-summary reporter omits session internals and prints summary on suite finish", async () => {
+  const writes: string[] = [];
+  const reporter = createJsonSummaryReporter({
+    stdout: {
+      write(chunk: string) {
+        writes.push(chunk);
+        return true;
+      },
+    },
+  });
+
+  const runner = createRunnerInfo("open-main", { type: "opencode", model: "openai/gpt-5" });
+  const result: SuiteRunResult = {
+    suitePath: "examples/basic-suite.ts",
+    startedAt: "2026-04-02T12:00:00.000Z",
+    endedAt: "2026-04-02T12:01:00.000Z",
+    durationMs: 60_000,
+    outputDir: ".skillgym-results/run-1",
+    cases: [
+      {
+        caseId: "case-a",
+        passed: false,
+        runnerResults: [
+          {
+            runner,
+            passed: false,
+            durationMs: 18_200,
+            artifactDir: ".skillgym-results/run-1/case-a/open-main",
+            failureType: "assertion",
+            failureOrigin: "assertion",
+            failureLogPath: ".skillgym-results/run-1/case-a/open-main/stderr.log",
+            error: {
+              name: "AssertionError",
+              message: "expected skill to be loaded",
+              stack: "AssertionError: expected skill to be loaded\n    at /workspace/suite.ts:10:5",
+            },
+            report: {
+              runner,
+              sessionId: "sess-abc123",
+              prompt: "Do the thing",
+              usage: {
+                inputTokens: 1000,
+                outputTokens: 200,
+                reasoningTokens: 50,
+                cacheTokens: 400,
+                totalTokens: 1200,
+                inputChars: 4000,
+                outputChars: 800,
+                reasoningChars: 200,
+                source: { input: "provider", output: "provider", reasoning: "derived" },
+              },
+              files: {
+                observedReads: ["/workspace/src/index.ts"],
+                observedSkillReads: ["/workspace/.claude/skills/my-skill.md"],
+              },
+              detectedSkills: [{ skill: "my-skill", confidence: "explicit", evidence: ["loaded skill"] }],
+              events: [
+                { type: "toolCall", tool: "Read", args: { file_path: "/workspace/src/index.ts" }, at: "2026-04-02T12:00:01.000Z" },
+                { type: "message", role: "assistant", text: "I'll read the file.", at: "2026-04-02T12:00:02.000Z" },
+              ],
+              finalOutput: "Done.",
+              startedAt: "2026-04-02T12:00:00.000Z",
+              endedAt: "2026-04-02T12:00:18.000Z",
+              durationMs: 18_200,
+              rawArtifacts: {
+                stdoutPath: ".skillgym-results/run-1/case-a/open-main/stdout.log",
+                sessionPath: ".skillgym-results/run-1/case-a/open-main/session.json",
+              },
+            },
+          },
+        ],
+      },
+    ],
+    runners: [
+      {
+        runner,
+        totalCases: 1,
+        passedCases: 0,
+        successRate: 0,
+        averageDurationMs: 18_200,
+        averageTotalTokens: 1200,
+      },
+    ],
+  };
+
+  const context = {
+    isInteractive: false,
+    cwd: "/workspace",
+    workspaceMode: "shared" as const,
+    suitePath: result.suitePath,
+    outputDir: result.outputDir,
+    selectedCaseCount: 1,
+    selectedRunnerCount: 1,
+    selectedExecutionCount: 1,
+    scheduleMode: "serial" as const,
+  };
+
+  await reporter.onSuiteStart?.({ context, cases: [], runners: [runner], startedAt: result.startedAt });
+  await reporter.onSuiteFinish?.({ context, result });
+
+  expect(writes).toHaveLength(1);
+  const output = JSON.parse(writes[0]!);
+
+  // top-level suite fields preserved
+  expect(output.suitePath).toBe("examples/basic-suite.ts");
+  expect(output.startedAt).toBe("2026-04-02T12:00:00.000Z");
+  expect(output.durationMs).toBe(60_000);
+  expect(output.outputDir).toBe(".skillgym-results/run-1");
+
+  // runner summaries preserved
+  expect(output.runners).toHaveLength(1);
+  expect(output.runners[0].runner.id).toBe("open-main");
+
+  // case result preserved
+  const caseResult = output.cases[0];
+  expect(caseResult.caseId).toBe("case-a");
+  expect(caseResult.passed).toBe(false);
+
+  // runner result: core fields preserved
+  const runnerResult = caseResult.runnerResults[0];
+  expect(runnerResult.runner.id).toBe("open-main");
+  expect(runnerResult.passed).toBe(false);
+  expect(runnerResult.durationMs).toBe(18_200);
+  expect(runnerResult.artifactDir).toBe(".skillgym-results/run-1/case-a/open-main");
+  expect(runnerResult.failureType).toBe("assertion");
+  expect(runnerResult.failureOrigin).toBe("assertion");
+
+  // error: name and message preserved, stack omitted
+  expect(runnerResult.error.name).toBe("AssertionError");
+  expect(runnerResult.error.message).toBe("expected skill to be loaded");
+  expect(runnerResult.error.stack).toBeUndefined();
+
+  // usage preserved
+  expect(runnerResult.usage.inputTokens).toBe(1000);
+  expect(runnerResult.usage.totalTokens).toBe(1200);
+
+  // session internals omitted
+  expect(runnerResult.report).toBeUndefined();
+  expect(runnerResult.failureLogPath).toBeUndefined();
+
+  // no events, prompts, files, skills, artifacts
+  const text = writes[0]!;
+  expect(text).not.toContain("events");
+  expect(text).not.toContain("toolCall");
+  expect(text).not.toContain("sessionId");
+  expect(text).not.toContain("prompt");
+  expect(text).not.toContain("detectedSkills");
+  expect(text).not.toContain("rawArtifacts");
+  expect(text).not.toContain("finalOutput");
+  expect(text).not.toContain("failureLogPath");
+  expect(text).not.toContain("stack");
+});
+
+test("json-summary reporter is silent until suite finishes", async () => {
+  const writes: string[] = [];
+  const reporter = createJsonSummaryReporter({
+    stdout: {
+      write(chunk: string) {
+        writes.push(chunk);
+        return true;
+      },
+    },
+  });
+
+  const runner = createRunnerInfo("r", { type: "codex", model: "gpt-5" });
+  const context = {
+    isInteractive: false,
+    cwd: "/workspace",
+    workspaceMode: "shared" as const,
+    suitePath: "suite.ts",
+    outputDir: ".out",
+    selectedCaseCount: 1,
+    selectedRunnerCount: 1,
+    selectedExecutionCount: 1,
+    scheduleMode: "serial" as const,
+  };
+
+  await reporter.onSuiteStart?.({ context, cases: [], runners: [runner], startedAt: "2026-04-02T12:00:00.000Z" });
+  await reporter.onRunnerStart?.({ context, testCase: { id: "c", prompt: "", assert() {} }, runner, caseIndex: 1, totalCases: 1 });
+  await reporter.onRunnerFinish?.({
+    context,
+    testCase: { id: "c", prompt: "", assert() {} },
+    runner,
+    result: {
+      runner,
+      passed: true,
+      durationMs: 1000,
+      artifactDir: ".out/c/r",
+      report: {
+        runner,
+        prompt: "",
+        usage: { inputChars: 0, outputChars: 0, reasoningChars: 0, source: { input: "provider", output: "provider", reasoning: "provider" } },
+        files: { observedReads: [], observedSkillReads: [] },
+        detectedSkills: [],
+        events: [],
+        finalOutput: "",
+        rawArtifacts: {},
+      },
+    },
+    caseIndex: 1,
+    totalCases: 1,
+  });
+
+  expect(writes).toHaveLength(0);
+});

--- a/test/reporters/json.test.ts
+++ b/test/reporters/json.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "vitest";
+import type { SuiteRunResult } from "../../src/index.js";
+import { createJsonReporter } from "../../src/reporters/json.js";
+
+test("json reporter prints only the final suite result", async () => {
+  const writes: string[] = [];
+  const reporter = createJsonReporter({
+    stdout: {
+      write(chunk: string) {
+        writes.push(chunk);
+        return true;
+      },
+    },
+  });
+
+  const result: SuiteRunResult = {
+    suitePath: "examples/basic-suite.ts",
+    startedAt: "2026-04-02T12:00:00.000Z",
+    endedAt: "2026-04-02T12:01:00.000Z",
+    durationMs: 60_000,
+    outputDir: ".skillgym-results/run-1",
+    cases: [],
+    runners: [],
+  };
+
+  await reporter.onSuiteStart?.({
+    context: {
+      isInteractive: false,
+      cwd: "/workspace",
+      workspaceMode: "shared",
+      suitePath: result.suitePath,
+      outputDir: result.outputDir,
+      selectedCaseCount: 0,
+      selectedRunnerCount: 0,
+      selectedExecutionCount: 0,
+      scheduleMode: "serial",
+    },
+    cases: [],
+    runners: [],
+    startedAt: result.startedAt,
+  });
+  await reporter.onSuiteFinish?.({
+    context: {
+      isInteractive: false,
+      cwd: "/workspace",
+      workspaceMode: "shared",
+      suitePath: result.suitePath,
+      outputDir: result.outputDir,
+      selectedCaseCount: 0,
+      selectedRunnerCount: 0,
+      selectedExecutionCount: 0,
+      scheduleMode: "serial",
+    },
+    result,
+  });
+
+  expect(writes).toEqual([`${JSON.stringify(result, null, 2)}\n`]);
+});

--- a/test/reporters/load-reporter.test.ts
+++ b/test/reporters/load-reporter.test.ts
@@ -28,6 +28,20 @@ describe("loadReporter", () => {
     expect(typeof reporter.onCaseFinish).toBe("function");
   });
 
+  test("resolves built-in reporter when json is provided", async () => {
+    const reporter = await loadReporter("json", tempDir);
+
+    expect(typeof reporter.onSuiteFinish).toBe("function");
+    expect(reporter.onSuiteStart).toBeUndefined();
+  });
+
+  test("resolves built-in reporter when github-actions is provided", async () => {
+    const reporter = await loadReporter("github-actions", tempDir);
+
+    expect(typeof reporter.onSuiteFinish).toBe("function");
+    expect(reporter.onRunnerFinish).toBeUndefined();
+  });
+
   test("loads custom reporter from relative default export path", async () => {
     const filePath = path.join(tempDir, "default-reporter.ts");
     await writeFile(filePath, 'export default { onSuiteStart() {} };\n', "utf8");

--- a/test/reporters/standard.test.ts
+++ b/test/reporters/standard.test.ts
@@ -84,6 +84,8 @@ test("standard reporter prints runner-grouped results and failure artifacts", as
 
   const output = writes.join("");
 
+  expect(output).toContain("skillgym");
+  expect(output).toContain("Prove your agent skills work before you ship them.");
   expect(output).toContain("Suite     examples/basic-suite.ts");
   expect(output).toContain("Runners   2");
   expect(output).toContain("Runs      4");


### PR DESCRIPTION
## Summary
Add first-party `json` and `github-actions` reporters so CI can consume final suite results without custom reporter plumbing.

## Context
Reporter loading still uses the existing single `reporter` string model, with `standard` remaining the default and custom file-path reporters continuing to work. The `json` reporter emits only the final aggregated `SuiteRunResult` to stdout, while the `github-actions` reporter emits failure annotations and appends a compact step summary when `GITHUB_STEP_SUMMARY` is available.

The GitHub Actions reporter intentionally stops at workflow annotations and job summaries. It does not post PR comments or call the GitHub API directly, so PR commenting can stay as a separate CI step.

Fixes #6

## Proposed Testing Scenario
Run a suite with `--reporter json` and confirm stdout is final `SuiteRunResult` JSON while the run still writes the usual `results.json` artifact. Then run the same suite in GitHub Actions with `--reporter github-actions`, force at least one failing run, and verify that the workflow shows one annotation per failed run plus a compact Markdown step summary when `GITHUB_STEP_SUMMARY` is set.