### PR TITLE
Add soft assertion aggregation for test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,11 @@ See [Workspaces](docs/workspaces.md) for the full workspace reference.
 
 `assert` extends Node's `node:assert/strict` helpers, so standard methods like `assert.ok`, `assert.equal`, and `assert.match` still work.
 
+`assert.soft.*` mirrors the same sync assertion surface and collects failures until the current test case finishes, so one run can report multiple assertion mismatches together.
+
 Built-in grouped assertions cover:
 
+- `assert.soft.*`
 - `assert.skills.*`
 - `assert.commands.*`
 - `assert.fileReads.*`
@@ -214,6 +217,8 @@ Example:
 ```ts
 import { assert, commandMatcher } from "skillgym";
 
+assert.soft.match(report.finalOutput, /ready/i);
+assert.soft.commands.includes(report, "pnpm test");
 assert.skills.has(report, "find-skills");
 assert.skills.notHas(report, "upgrading-expo");
 assert.commands.includes(report, "npx skills find");
@@ -227,6 +232,8 @@ assert.toolCalls.has(report, {
 });
 assert.output.notEmpty(report);
 ```
+
+`assert.soft.rejects(...)` and `assert.soft.doesNotReject(...)` are still hard assertions in the first implementation.
 
 See the [assertion reference](docs/assertions.md).
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -4,6 +4,7 @@
 
 - Node's `node:assert/strict` API
 - grouped helpers for normalized session reports
+- `assert.soft.*` for Jest/Vitest-style sync soft assertions
 
 ```ts
 import { assert } from "skillgym";
@@ -11,15 +12,34 @@ import { assert } from "skillgym";
 assert.ok(true);
 assert.equal(1, 1);
 assert.match("skillgym ready", /ready/);
+assert.soft.match("skillgym ready", /ready/);
 ```
 
 ## Report helper groups
 
+- `assert.soft.*`
 - `assert.skills.*`
 - `assert.commands.*`
 - `assert.fileReads.*`
 - `assert.toolCalls.*`
 - `assert.output.*`
+
+## Soft assertions
+
+`assert.soft` mirrors the sync assertion methods on the root `assert` export and the grouped SkillGym helpers.
+
+- soft failures are collected in execution order
+- the runner throws a single `AssertionError` after `testCase.assert(report, ctx)` completes
+- if a hard `AssertionError` is thrown after soft failures were collected, the final failure includes both
+- `assert.soft.rejects(...)` and `assert.soft.doesNotReject(...)` remain hard assertions in the first implementation
+
+Example:
+
+```ts
+assert.soft.match(report.finalOutput, /ready/i);
+assert.soft.commands.includes(report, "pnpm test");
+assert.soft.output.notEmpty(report);
+```
 
 ## Shared matcher types
 

--- a/src/assertions/assert.ts
+++ b/src/assertions/assert.ts
@@ -3,10 +3,12 @@ import { commandAssertions } from "./commands.js";
 import { fileReadAssertions } from "./file-reads.js";
 import { outputAssertions } from "./output.js";
 import { skillAssertions } from "./skills.js";
+import { softAssert } from "./soft.js";
 import { toolCallAssertions } from "./tool-calls.js";
 import type { SkillGymAssert } from "./types.js";
 
 export const assert: SkillGymAssert = Object.assign(nodeAssert, {
+  soft: softAssert,
   skills: skillAssertions,
   commands: commandAssertions,
   fileReads: fileReadAssertions,

--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -1,4 +1,5 @@
 export { assert } from "./assert.js";
+export { runWithSoftAssertions } from "./soft.js";
 export { CommandMatcherBuilder, commandMatcher } from "./command-matcher.js";
 export type {
   AssertionOptions,
@@ -12,6 +13,7 @@ export type {
   SkillAssertionOptions,
   SkillAssertions,
   SkillGymAssert,
+  SkillGymSoftAssert,
   SkillConfidence,
   StructuredCommandMatcher,
   ToolCallAssertions,

--- a/src/assertions/output.ts
+++ b/src/assertions/output.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { assertIncludes, composeAssertionMessage } from "./matchers.js";
 import type { OutputAssertions } from "./types.js";
 
@@ -6,11 +7,8 @@ export const outputAssertions: OutputAssertions = {
     assertIncludes("final output", [report.finalOutput], matcher, options);
   },
   notEmpty(report, options) {
-    if (report.finalOutput.length > 0) {
-      return;
-    }
-
-    throw new Error(
+    assert.ok(
+      report.finalOutput.length > 0,
       composeAssertionMessage(
         "Expected final output not to be empty.",
         "Observed final output: (empty)",

--- a/src/assertions/soft.ts
+++ b/src/assertions/soft.ts
@@ -40,7 +40,10 @@ const softAssertionGroups = {
   output: OutputAssertions;
 };
 
-export const softAssert: SkillGymSoftAssert = Object.assign(createSoftNodeAssert(), softAssertionGroups);
+export const softAssert: SkillGymSoftAssert = Object.assign(
+  createSoftNodeAssert(),
+  softAssertionGroups,
+);
 
 export async function runWithSoftAssertions<T>(callback: () => Promise<T> | T): Promise<T> {
   return await softAssertionStorage.run({ failures: [] }, async () => {
@@ -75,9 +78,14 @@ function createSoftNodeAssert(): typeof nodeAssert {
     if ("value" in descriptor) {
       if (key === "strict") {
         descriptor.value = wrapped;
-      } else if (typeof descriptor.value === "function" && key !== "rejects" && key !== "doesNotReject") {
+      } else if (
+        typeof descriptor.value === "function" &&
+        key !== "rejects" &&
+        key !== "doesNotReject"
+      ) {
         const method = descriptor.value;
-        descriptor.value = (...args: unknown[]) => captureSoftAssertion(() => method.apply(nodeAssert, args));
+        descriptor.value = (...args: unknown[]) =>
+          captureSoftAssertion(() => method.apply(nodeAssert, args));
       }
     }
 

--- a/src/assertions/soft.ts
+++ b/src/assertions/soft.ts
@@ -1,0 +1,165 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { AssertionError } from "node:assert";
+import nodeAssert from "node:assert/strict";
+import { commandAssertions } from "./commands.js";
+import { fileReadAssertions } from "./file-reads.js";
+import { outputAssertions } from "./output.js";
+import { skillAssertions } from "./skills.js";
+import { toolCallAssertions } from "./tool-calls.js";
+import type {
+  CommandAssertions,
+  FileReadAssertions,
+  OutputAssertions,
+  SkillAssertions,
+  SkillGymSoftAssert,
+  ToolCallAssertions,
+} from "./types.js";
+
+interface SoftAssertionCollector {
+  failures: AssertionError[];
+}
+
+type VoidFunction = (...args: any[]) => void;
+type SoftGroup<T> = {
+  [K in keyof T]: T[K] extends (...args: infer Args) => void ? (...args: Args) => void : never;
+};
+
+const softAssertionStorage = new AsyncLocalStorage<SoftAssertionCollector>();
+
+const softAssertionGroups = {
+  skills: createSoftGroup(skillAssertions),
+  commands: createSoftGroup(commandAssertions),
+  fileReads: createSoftGroup(fileReadAssertions),
+  toolCalls: createSoftGroup(toolCallAssertions),
+  output: createSoftGroup(outputAssertions),
+} satisfies {
+  skills: SkillAssertions;
+  commands: CommandAssertions;
+  fileReads: FileReadAssertions;
+  toolCalls: ToolCallAssertions;
+  output: OutputAssertions;
+};
+
+export const softAssert: SkillGymSoftAssert = Object.assign(createSoftNodeAssert(), softAssertionGroups);
+
+export async function runWithSoftAssertions<T>(callback: () => Promise<T> | T): Promise<T> {
+  return await softAssertionStorage.run({ failures: [] }, async () => {
+    try {
+      const result = await callback();
+      flushSoftAssertions();
+      return result;
+    } catch (error) {
+      if (error instanceof AssertionError) {
+        throw mergeCollectedSoftAssertions(error);
+      }
+
+      throw error;
+    }
+  });
+}
+
+function createSoftNodeAssert(): typeof nodeAssert {
+  const wrapped = ((...args: Parameters<typeof nodeAssert>) =>
+    captureSoftAssertion(() => nodeAssert(...args))) as typeof nodeAssert;
+
+  for (const key of Object.getOwnPropertyNames(nodeAssert)) {
+    if (key === "length" || key === "name" || key === "prototype") {
+      continue;
+    }
+
+    const descriptor = Object.getOwnPropertyDescriptor(nodeAssert, key);
+    if (descriptor === undefined) {
+      continue;
+    }
+
+    if ("value" in descriptor) {
+      if (key === "strict") {
+        descriptor.value = wrapped;
+      } else if (typeof descriptor.value === "function" && key !== "rejects" && key !== "doesNotReject") {
+        const method = descriptor.value;
+        descriptor.value = (...args: unknown[]) => captureSoftAssertion(() => method.apply(nodeAssert, args));
+      }
+    }
+
+    Object.defineProperty(wrapped, key, descriptor);
+  }
+
+  return wrapped;
+}
+
+function createSoftGroup<T extends object>(group: T): SoftGroup<T> {
+  const wrappedGroup = {} as SoftGroup<T>;
+
+  for (const key of Object.keys(group) as Array<keyof T>) {
+    const method = group[key];
+    if (typeof method !== "function") {
+      continue;
+    }
+
+    wrappedGroup[key] = ((...args: unknown[]) =>
+      captureSoftAssertion(() => (method as VoidFunction)(...args))) as SoftGroup<T>[typeof key];
+  }
+
+  return wrappedGroup;
+}
+
+function captureSoftAssertion<T>(callback: () => T): T {
+  try {
+    return callback();
+  } catch (error) {
+    if (!(error instanceof AssertionError)) {
+      throw error;
+    }
+
+    const collector = softAssertionStorage.getStore();
+    if (collector === undefined) {
+      throw error;
+    }
+
+    collector.failures.push(error);
+    return undefined as T;
+  }
+}
+
+function flushSoftAssertions(): void {
+  const collector = softAssertionStorage.getStore();
+  if (collector === undefined || collector.failures.length === 0) {
+    return;
+  }
+
+  throw createAggregateAssertionError(collector.failures.splice(0));
+}
+
+function mergeCollectedSoftAssertions(hardFailure: AssertionError): AssertionError {
+  const collector = softAssertionStorage.getStore();
+  if (collector === undefined || collector.failures.length === 0) {
+    return hardFailure;
+  }
+
+  return createAggregateAssertionError([...collector.failures.splice(0), hardFailure]);
+}
+
+function createAggregateAssertionError(failures: readonly AssertionError[]): AssertionError {
+  const count = failures.length;
+  const message = [
+    `${count} assertion failure${count === 1 ? "" : "s"} collected during test case execution:`,
+    ...failures.map((failure, index) => `${index + 1}. ${failure.message}`),
+  ].join("\n");
+
+  const error = new AssertionError({
+    message,
+    actual: count,
+    expected: 0,
+    operator: "softAssertions",
+  });
+
+  error.stack = [
+    `${error.name}: ${message}`,
+    ...failures.map((failure, index) => {
+      const stack = failure.stack ?? `${failure.name}: ${failure.message}`;
+      return `Assertion ${index + 1}\n${stack}`;
+    }),
+  ].join("\n\n");
+
+  return error;
+}

--- a/src/assertions/types.ts
+++ b/src/assertions/types.ts
@@ -154,7 +154,16 @@ export interface OutputAssertions {
   notEmpty(report: SessionReport, options?: AssertionOptions): void;
 }
 
+export type SkillGymSoftAssert = typeof nodeAssert & {
+  skills: SkillAssertions;
+  commands: CommandAssertions;
+  fileReads: FileReadAssertions;
+  toolCalls: ToolCallAssertions;
+  output: OutputAssertions;
+};
+
 export type SkillGymAssert = typeof nodeAssert & {
+  soft: SkillGymSoftAssert;
   skills: SkillAssertions;
   commands: CommandAssertions;
   fileReads: FileReadAssertions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ export type {
   SkillAssertionOptions,
   SkillAssertions,
   SkillGymAssert,
+  SkillGymSoftAssert,
   SkillConfidence,
   StructuredCommandMatcher,
   ToolCallAssertions,

--- a/src/runner/execute-runner.ts
+++ b/src/runner/execute-runner.ts
@@ -6,6 +6,7 @@ import type { RunnerInfo } from "../domain/runner.js";
 import type { SessionReport } from "../domain/session-report.js";
 import type { TestCase } from "../domain/test-case.js";
 import { createAssertionContext } from "../assertions/context.js";
+import { runWithSoftAssertions } from "../assertions/soft.js";
 import type { SnapshotRuntimeOptions, SnapshotStore } from "../snapshots/store.js";
 import { ensureDir, writeJson } from "../utils/fs.js";
 import { isCommandTimeoutError, isMaxStepsExceededError } from "../utils/process.js";
@@ -96,7 +97,7 @@ export async function executeRunner(
     const ctx = createAssertionContext(report);
 
     try {
-      await testCase.assert(report, ctx);
+      await runWithSoftAssertions(() => testCase.assert(report, ctx));
     } catch (error) {
       const isAssertionFailure = error instanceof AssertionError;
       return await writeAndReturnFailure(error, {

--- a/test/assertions/soft.test.ts
+++ b/test/assertions/soft.test.ts
@@ -1,0 +1,68 @@
+import nodeAssert, { AssertionError } from "node:assert/strict";
+import { test } from "vitest";
+import { assert, runWithSoftAssertions } from "../../src/assertions/index.js";
+import type { SessionReport } from "../../src/domain/session-report.js";
+import { createRunnerInfo } from "../../src/runner/runner-info.js";
+
+test("assert.soft collects multiple Node assertion failures", async () => {
+  await nodeAssert.rejects(
+    () =>
+      runWithSoftAssertions(() => {
+        assert.soft.equal(1, 2, "first soft failure");
+        assert.soft.match("skillgym ready", /failed/, "second soft failure");
+      }),
+    (error) => {
+      nodeAssert.ok(error instanceof AssertionError);
+      nodeAssert.match(
+        error.message,
+        /2 assertion failures collected during test case execution:/,
+      );
+      nodeAssert.match(error.message, /1\. first soft failure/);
+      nodeAssert.match(error.message, /2\. second soft failure/);
+      return true;
+    },
+  );
+});
+
+test("assert.soft collects grouped helper failures", async () => {
+  const report = createReport("");
+
+  await nodeAssert.rejects(
+    () =>
+      runWithSoftAssertions(() => {
+        assert.soft.output.notEmpty(report, { message: "expected output" });
+        assert.soft.commands.includes(report, "pnpm test", { message: "expected command" });
+      }),
+    (error) => {
+      nodeAssert.ok(error instanceof AssertionError);
+      nodeAssert.match(error.message, /expected output/);
+      nodeAssert.match(error.message, /expected command/);
+      return true;
+    },
+  );
+});
+
+function createReport(finalOutput: string): SessionReport {
+  return {
+    runner: createRunnerInfo("codex", { type: "codex", model: "gpt-5" }),
+    prompt: "test prompt",
+    usage: {
+      inputChars: 0,
+      outputChars: 0,
+      reasoningChars: 0,
+      source: {
+        input: "chars",
+        output: "chars",
+        reasoning: "chars",
+      },
+    },
+    files: {
+      observedReads: [],
+      observedSkillReads: [],
+    },
+    detectedSkills: [],
+    events: [],
+    finalOutput,
+    rawArtifacts: {},
+  };
+}

--- a/test/assertions/soft.test.ts
+++ b/test/assertions/soft.test.ts
@@ -13,10 +13,7 @@ test("assert.soft collects multiple Node assertion failures", async () => {
       }),
     (error) => {
       nodeAssert.ok(error instanceof AssertionError);
-      nodeAssert.match(
-        error.message,
-        /2 assertion failures collected during test case execution:/,
-      );
+      nodeAssert.match(error.message, /2 assertion failures collected during test case execution:/);
       nodeAssert.match(error.message, /1\. first soft failure/);
       nodeAssert.match(error.message, /2\. second soft failure/);
       return true;

--- a/test/runner/execute-runner.test.ts
+++ b/test/runner/execute-runner.test.ts
@@ -209,7 +209,9 @@ test("executeRunner flushes collected soft assertion failures after assert hook 
   expect(result.passed).toBe(false);
   expect(result.failureType).toBe("assertion");
   expect(result.failureOrigin).toBe("assertion");
-  expect(result.error?.message).toContain("2 assertion failures collected during test case execution");
+  expect(result.error?.message).toContain(
+    "2 assertion failures collected during test case execution",
+  );
   expect(result.error?.message).toContain("expected output");
   expect(result.error?.message).toContain("expected command");
 });
@@ -239,7 +241,9 @@ test("executeRunner merges soft failures with a later hard AssertionError", asyn
 
   expect(result.passed).toBe(false);
   expect(result.failureType).toBe("assertion");
-  expect(result.error?.message).toContain("2 assertion failures collected during test case execution");
+  expect(result.error?.message).toContain(
+    "2 assertion failures collected during test case execution",
+  );
   expect(result.error?.message).toContain("soft failure");
   expect(result.error?.message).toContain("hard failure");
 });

--- a/test/runner/execute-runner.test.ts
+++ b/test/runner/execute-runner.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { AssertionError } from "node:assert";
 import { afterEach, expect, test } from "vitest";
+import { assert as skillgymAssert } from "../../src/assertions/index.js";
 import type {
   RawRunArtifacts,
   RunHandle,
@@ -180,6 +181,108 @@ test("executeRunner treats non-AssertionError exceptions from assert as run fail
   expect(result.failureOrigin).toBe("assert-hook");
   expect(result.error?.message).toBe("assert hook crashed intentionally");
   expect(result.report.usage.totalTokens).toBe(120);
+});
+
+test("executeRunner flushes collected soft assertion failures after assert hook completes", async () => {
+  const outputDir = await createTempDir();
+  const runner = createRunnerInfo("open-main", { type: "opencode", model: "openai/gpt-5" });
+  const adapter = createSuccessfulAdapter(runner, { totalTokens: 120 });
+
+  const result = await executeRunner(
+    {
+      id: "alpha",
+      prompt: "prompt",
+      assert(report) {
+        skillgymAssert.soft.output.notEmpty(report, { message: "expected output" });
+        skillgymAssert.soft.commands.includes(report, "pnpm test", { message: "expected command" });
+      },
+    },
+    runner,
+    adapter,
+    {
+      cwd: outputDir,
+      artifactDir: path.join(outputDir, "alpha", runner.pathKey),
+      timeoutMs: 5_000,
+    },
+  );
+
+  expect(result.passed).toBe(false);
+  expect(result.failureType).toBe("assertion");
+  expect(result.failureOrigin).toBe("assertion");
+  expect(result.error?.message).toContain("2 assertion failures collected during test case execution");
+  expect(result.error?.message).toContain("expected output");
+  expect(result.error?.message).toContain("expected command");
+});
+
+test("executeRunner merges soft failures with a later hard AssertionError", async () => {
+  const outputDir = await createTempDir();
+  const runner = createRunnerInfo("open-main", { type: "opencode", model: "openai/gpt-5" });
+  const adapter = createSuccessfulAdapter(runner, { totalTokens: 120 });
+
+  const result = await executeRunner(
+    {
+      id: "alpha",
+      prompt: "prompt",
+      assert(report) {
+        skillgymAssert.soft.output.notEmpty(report, { message: "soft failure" });
+        throw new AssertionError({ message: "hard failure" });
+      },
+    },
+    runner,
+    adapter,
+    {
+      cwd: outputDir,
+      artifactDir: path.join(outputDir, "alpha", runner.pathKey),
+      timeoutMs: 5_000,
+    },
+  );
+
+  expect(result.passed).toBe(false);
+  expect(result.failureType).toBe("assertion");
+  expect(result.error?.message).toContain("2 assertion failures collected during test case execution");
+  expect(result.error?.message).toContain("soft failure");
+  expect(result.error?.message).toContain("hard failure");
+});
+
+test("executeRunner clears soft assertion state between runs", async () => {
+  const outputDir = await createTempDir();
+  const runner = createRunnerInfo("open-main", { type: "opencode", model: "openai/gpt-5" });
+  const adapter = createSuccessfulAdapter(runner, { totalTokens: 120 });
+
+  const failed = await executeRunner(
+    {
+      id: "alpha",
+      prompt: "prompt",
+      assert(report) {
+        skillgymAssert.soft.output.notEmpty(report, { message: "soft failure" });
+      },
+    },
+    runner,
+    adapter,
+    {
+      cwd: outputDir,
+      artifactDir: path.join(outputDir, "alpha", runner.pathKey),
+      timeoutMs: 5_000,
+    },
+  );
+
+  const passed = await executeRunner(
+    {
+      id: "beta",
+      prompt: "prompt",
+      assert() {},
+    },
+    runner,
+    adapter,
+    {
+      cwd: outputDir,
+      artifactDir: path.join(outputDir, "beta", runner.pathKey),
+      timeoutMs: 5_000,
+    },
+  );
+
+  expect(failed.passed).toBe(false);
+  expect(passed.passed).toBe(true);
 });
 
 test("executeRunner marks timeout failures separately from runner crashes", async () => {


### PR DESCRIPTION
## Summary
Add `assert.soft.*` so SkillGym test cases can collect multiple sync assertion failures and report them together at the end of the assert hook.

## Context
This wraps the existing Node strict assert surface and SkillGym grouped helpers in an execution-scoped soft assertion collector, then flushes or merges failures in `executeRunner` as one final `AssertionError`. It keeps runner failure classification stable, limits the first pass to sync assertions, and adds coverage for pure soft failures, mixed soft plus hard failures, and state isolation between runs.

Fixes https://github.com/callstackincubator/skillgym/issues/18

## Proposed Testing Scenario
Run a suite where one test case calls multiple `assert.soft.*` helpers and confirm the run fails once with all assertion messages listed in order after the assert hook completes. Then add a hard assertion after a soft failure and confirm the final failure still comes through as a single assertion failure that includes both messages.