### PR TITLE
Fix Cursor tool-call normalization duplicates

### DIFF
--- a/src/adapters/cursor-agent.ts
+++ b/src/adapters/cursor-agent.ts
@@ -71,6 +71,9 @@ export class CursorAgentAdapter extends BaseAdapter implements RunnerAdapter {
     const observedReads: string[] = [];
     const explicitSkillNames = new Set<string>();
     const seenToolCalls = new Set<string>();
+    const seenCommands = new Set<string>();
+    const seenReadPaths = new Set<string>();
+    const seenSkillSignals = new Set<string>();
     const callBaseDirs = new Map<string, string>();
 
     let sessionCwd = input.cwd;
@@ -110,7 +113,7 @@ export class CursorAgentAdapter extends BaseAdapter implements RunnerAdapter {
           continue;
         }
 
-        const callId = readString(record, "call_id");
+        const callId = readCursorToolCallId(record);
         const isCompleted = readString(record, "subtype") === "completed";
         const hasEmittedCall = callId !== undefined && seenToolCalls.has(callId);
         const baseDir =
@@ -118,7 +121,7 @@ export class CursorAgentAdapter extends BaseAdapter implements RunnerAdapter {
             ? resolveToolBaseDir(toolCall.args, sessionCwd)
             : resolveCursorCallBaseDir(callId, toolCall.args, sessionCwd, callBaseDirs);
 
-        if (!hasEmittedCall) {
+        if (!hasEmittedCall && !isCompleted) {
           events.push({
             type: "toolCall",
             tool: toolCall.tool,
@@ -132,11 +135,14 @@ export class CursorAgentAdapter extends BaseAdapter implements RunnerAdapter {
         }
 
         const command = extractCommand(toolCall.tool, toolCall.args);
-        if (command !== undefined) {
+        if (command !== undefined && shouldEmitCursorCallDetail(seenCommands, callId, command)) {
           events.push({ type: "command", command, at });
           for (const filePath of extractFilePathsFromCommand(command)) {
             const resolvedPath = resolveReportedPath(filePath, baseDir);
-            if (resolvedPath === undefined) {
+            if (
+              resolvedPath === undefined ||
+              !shouldEmitCursorCallDetail(seenReadPaths, callId, resolvedPath)
+            ) {
               continue;
             }
 
@@ -148,14 +154,20 @@ export class CursorAgentAdapter extends BaseAdapter implements RunnerAdapter {
         const readPath = extractReadPath(toolCall.tool, toolCall.args);
         if (readPath !== undefined) {
           const resolvedPath = resolveReportedPath(readPath, baseDir);
-          if (resolvedPath !== undefined) {
+          if (
+            resolvedPath !== undefined &&
+            shouldEmitCursorCallDetail(seenReadPaths, callId, resolvedPath)
+          ) {
             observedReads.push(resolvedPath);
             events.push({ type: "fileRead", path: resolvedPath, at });
           }
         }
 
         const skillName = extractSkillName(toolCall.tool, toolCall.args);
-        if (skillName !== undefined) {
+        if (
+          skillName !== undefined &&
+          shouldEmitCursorCallDetail(seenSkillSignals, callId, skillName)
+        ) {
           explicitSkillNames.add(skillName);
           events.push({ type: "skillSignal", skill: skillName, signal: "tool:skill", at });
         }
@@ -297,6 +309,10 @@ function readTimestamp(record: Record<string, unknown>): string | undefined {
   return typeof timestamp === "number" ? new Date(timestamp).toISOString() : undefined;
 }
 
+function readCursorToolCallId(record: Record<string, unknown>): string | undefined {
+  return readString(record, "call_id") ?? readString(record, "model_call_id");
+}
+
 function extractMessageText(message: Record<string, unknown>): string {
   const content = message.content;
   if (!Array.isArray(content)) {
@@ -394,6 +410,24 @@ function readToolBaseDir(args: unknown): string | undefined {
   }
 
   return readString(args, "workingDirectory") ?? readString(args, "cwd");
+}
+
+function shouldEmitCursorCallDetail(
+  seenValues: Set<string>,
+  callId: string | undefined,
+  value: string,
+): boolean {
+  if (callId === undefined) {
+    return true;
+  }
+
+  const key = `${callId}\u0000${value}`;
+  if (seenValues.has(key)) {
+    return false;
+  }
+
+  seenValues.add(key);
+  return true;
 }
 
 function stringifyUnknown(value: unknown): string {

--- a/test/adapters/cursor-agent.test.ts
+++ b/test/adapters/cursor-agent.test.ts
@@ -173,6 +173,8 @@ test("CursorAgentAdapter normalize extracts commands, file reads, tool results, 
   expect(report.detectedSkills).toEqual(
     expect.arrayContaining([expect.objectContaining({ skill: "find-skills" })]),
   );
+  expect(report.events.filter((event) => event.type === "toolCall")).toHaveLength(1);
+  expect(report.events.filter((event) => event.type === "command")).toHaveLength(1);
   expect(report.events).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -242,6 +244,7 @@ test("CursorAgentAdapter normalize resolves shell reads against stored call work
   expect(report.files.observedReads).toEqual([
     "/tmp/isolated-workspace/skills/find-skills/SKILL.md",
   ]);
+  expect(report.events.filter((event) => event.type === "fileRead")).toHaveLength(1);
   expect(report.events).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -297,6 +300,7 @@ test("CursorAgentAdapter normalize resolves read tool calls against stored call 
   expect(report.detectedSkills).toEqual(
     expect.arrayContaining([expect.objectContaining({ skill: "find-skills" })]),
   );
+  expect(report.events.filter((event) => event.type === "fileRead")).toHaveLength(1);
   expect(report.events).toEqual(
     expect.arrayContaining([
       expect.objectContaining({


### PR DESCRIPTION
## Summary
- validate the bug against a real Cursor Agent run: the raw `session.stream.jsonl` emitted both `tool_call.started` and `tool_call.completed` for one shell invocation, while normalization produced duplicate downstream command events
- make Cursor normalization subtype-aware by keeping completion results but deduplicating command, file-read, and skill-signal extraction per logical call id
- add regression coverage so started/completed pairs only emit one normalized tool call, one command, and one file read

## Validation
- real Cursor repro before fix: raw artifact contained one logical shell call split into `tool_call.started` and `tool_call.completed`, while normalized output contained two `command` events
- real Cursor repro after fix: raw artifact still contains both subtypes, while normalized output now contains one `toolCall`, one `command`, and one `toolResult`
- repro artifacts used during validation live under `/var/folders/tb/j39z273s5kn7lb9tz1dhk8l00000gn/T/opencode/issue-24-cursor-repro*`

## Testing
- `npm test -- test/adapters/cursor-agent.test.ts test/limits/max-steps.test.ts`
- `npm run typecheck`

Closes #24.