### PR TITLE
Restore TestCase and TestSuite export aliases

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ export type { ScheduleMode } from "./domain/schedule.js";
 export type {
   Case,
   Suite,
+  Case as TestCase,
+  Suite as TestSuite,
   AssertionContext,
   SuiteWorkspaceConfig,
   WorkspaceBootstrapConfig,

--- a/test/public-api.test.ts
+++ b/test/public-api.test.ts
@@ -1,0 +1,12 @@
+import { describe, expectTypeOf, it } from "vitest";
+import type { Case, Suite, TestCase, TestSuite } from "../src/index.js";
+
+describe("public API compatibility", () => {
+  it("exports TestCase as an alias of Case", () => {
+    expectTypeOf<TestCase>().toEqualTypeOf<Case>();
+  });
+
+  it("exports TestSuite as an alias of Suite", () => {
+    expectTypeOf<TestSuite>().toEqualTypeOf<Suite>();
+  });
+});


### PR DESCRIPTION
## Summary
Restore `TestCase` and `TestSuite` as public type aliases from the package root so existing suite files keep compiling after the vocabulary normalization.

## Context
The vocabulary update renamed these public types to `Case` and `Suite`, which is fine for new code but can break users who already import `TestCase` and `TestSuite` in their suite definitions. Re-exporting aliases keeps the normalized naming internally while preserving the API that existing users depend on.

This matters to users because their suite files are part of their test harness. If a release removes previously exported type names, upgrading can fail at compile time even though the underlying suite shape still works.

## Proposed Testing Scenario
Create or use an existing suite file that imports `TestCase` or `TestSuite` from `skillgym`, then typecheck it against this branch. The suite should compile unchanged, and imports using the newer `Case` and `Suite` names should continue to work as well.