### PR TITLE
Raise process listener limit for parallel runs

### DIFF
--- a/src/runner/execute-suite.ts
+++ b/src/runner/execute-suite.ts
@@ -189,6 +189,7 @@ export async function executeSuite(
   const plannedExecutions = createPlannedExecutions(selectedCases, selectedRunners, options.config);
   const caseStates = createPlannedCaseStates(selectedCases.length);
   const rejectedRunners = new Map<string, RunnerResult>();
+  const restoreMaxListeners = raiseProcessMaxListeners(resolveProcessMaxListeners(maxParallel));
 
   try {
     await options.reporter?.onSuiteStart?.({
@@ -271,7 +272,26 @@ export async function executeSuite(
   } catch (error) {
     await options.reporter?.onError?.({ context, error });
     throw error;
+  } finally {
+    restoreMaxListeners();
   }
+}
+
+function resolveProcessMaxListeners(maxParallel: number): number {
+  return Math.max(process.getMaxListeners(), maxParallel * 2);
+}
+
+function raiseProcessMaxListeners(target: number): () => void {
+  const previous = process.getMaxListeners();
+
+  if (target <= previous) {
+    return () => {};
+  }
+
+  process.setMaxListeners(target);
+  return () => {
+    process.setMaxListeners(previous);
+  };
 }
 
 export function classifyExpectedFailure(case_: Case, result: RunnerResult): RunnerResult {

--- a/test/runner/execute-suite.reporter.test.ts
+++ b/test/runner/execute-suite.reporter.test.ts
@@ -1453,6 +1453,47 @@ test("executeSuite snapshots use the average of successful repetitions", async (
   expect(saved.entries["alpha::open"]?.value).toBe(150);
 });
 
+test("executeSuite raises process max listeners for parallel runs and restores it", async () => {
+  const suiteRunArtifactDir = await createTempDir();
+  const originalMaxListeners = process.getMaxListeners();
+  const observedMaxListeners: number[] = [];
+  const cases: Case[] = [
+    { id: "alpha", prompt: "a", assert() {} },
+    { id: "beta", prompt: "b", assert() {} },
+  ];
+
+  try {
+    await executeSuite("./suite.ts", cases, {
+      cwd: suiteRunArtifactDir,
+      outputDir: suiteRunArtifactDir,
+      schedule: "parallel",
+      maxParallel: originalMaxListeners + 2,
+      isInteractive: false,
+      config: {
+        runners: {
+          open: { agent: { type: "opencode", model: "openai/gpt-5" } },
+          code: { agent: { type: "codex", model: "gpt-5" } },
+        },
+      },
+      executeRunnerFn: async (case_, runner, _adapter, options) => {
+        observedMaxListeners.push(process.getMaxListeners());
+        return createRunnerResult({
+          caseId: case_.id,
+          runner,
+          passed: true,
+          durationMs: 10,
+          executionArtifactDir: options.artifactDir,
+        });
+      },
+    });
+  } finally {
+    expect(process.getMaxListeners()).toBe(originalMaxListeners);
+  }
+
+  expect(observedMaxListeners).not.toHaveLength(0);
+  expect(Math.min(...observedMaxListeners)).toBe((originalMaxListeners + 2) * 2);
+});
+
 function createRunnerResultForKey(
   caseId: string,
   runnerId: string,


### PR DESCRIPTION
## Summary
Raise the process max listener limit during a suite run based on `maxParallel`, then restore the original limit afterward.

## Context
Node starts warning after more than 10 listeners are attached to the same process event. SkillGym attaches signal listeners while subprocesses are active, so higher-parallel runs can emit `MaxListenersExceededWarning` even when the run itself is expected and healthy.

This change keeps the current signal-handling model, but scales the listener cap to match the requested parallelism for the duration of the run. That matters to users because larger parallel runs should not produce noisy warnings just because they intentionally configured more concurrency than Node's default listener threshold.

## Proposed Testing Scenario
Run a suite with `--schedule parallel` and a `--max-parallel` value above Node's default listener threshold. The run should proceed without `MaxListenersExceededWarning`, and normal lower-parallel runs should behave the same as before.