### PR TITLE
Add built-in HTML reporter

### DIFF
--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -11,12 +11,13 @@ skillgym run <suite.ts> --reporter standard
 skillgym run <suite.ts> --reporter json
 skillgym run <suite.ts> --reporter json-summary
 skillgym run <suite.ts> --reporter github-actions
+skillgym run <suite.ts> --reporter html
 skillgym run <suite.ts> --reporter ./examples/custom-reporter.ts
 skillgym run <suite.ts> --schedule isolated-by-runner --max-parallel 4
 ```
 
 - Omitting `--reporter` uses the built-in `standard` reporter.
-- Built-in reporters are `standard`, `json`, `json-summary`, and `github-actions`.
+- Built-in reporters are `standard`, `json`, `json-summary`, `github-actions`, and `html`.
 - Relative paths resolve from `process.cwd()`.
 
 ## Config
@@ -136,6 +137,17 @@ The built-in `json-summary` reporter writes a trimmed JSON summary to stdout —
 - The output includes per-case and per-runner results with token usage, pass/fail status, artifact paths, and error details, but omits the full session events and raw artifact data.
 - Per-runner results include `failureClass` when present so downstream tooling can keep grouped-failure semantics.
 - It is useful for post-run analysis steps or feeding results to an LLM.
+
+## HTML reporter
+
+The built-in `html` reporter writes a self-contained `report.html` file to the suite run artifact directory.
+
+- It renders a collapsible tree: suite summary → case → runner execution → individual session events.
+- Each runner block shows pass/fail status, duration, and token usage (input/output).
+- Assistant messages, tool calls, file reads, and commands are rendered as expandable `<details>` elements.
+- The final output of each execution is shown in a collapsible block.
+- Errors are shown inline when present.
+- The output path is printed to stdout after the file is written.
 
 ## GitHub Actions reporter
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export { assert, CommandMatcherBuilder, commandMatcher } from "./assertions/inde
 export {
   BUILT_IN_REPORTER_NAMES,
   createGitHubActionsReporter,
+  createHtmlReporter,
   createJsonReporter,
   createStandardReporter,
   loadReporter,

--- a/src/reporters/builtins.ts
+++ b/src/reporters/builtins.ts
@@ -3,6 +3,7 @@ export const BUILT_IN_REPORTER_NAMES = [
   "json",
   "json-summary",
   "github-actions",
+  "html",
 ] as const;
 
 export type BuiltInReporterName = (typeof BUILT_IN_REPORTER_NAMES)[number];

--- a/src/reporters/html.ts
+++ b/src/reporters/html.ts
@@ -1,0 +1,133 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { CaseResult, RunnerResult, SuiteRunResult } from "../domain/result.js";
+import type { Case } from "../domain/case.js";
+import type { SessionEvent } from "../domain/session-report.js";
+import type { BenchmarkReporter, CaseFinishEvent } from "./contract.js";
+
+function esc(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function ms(n: number | undefined): string {
+  if (n == null) return "—";
+  return n < 1000 ? `${n}ms` : `${(n / 1000).toFixed(1)}s`;
+}
+
+function tokens(n: number | undefined): string {
+  if (n == null) return "—";
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+}
+
+function renderEvent(e: SessionEvent): string {
+  if (e.type === "message" && e.role === "assistant") {
+    return `<details><summary>assistant message</summary><pre>${esc(e.text)}</pre></details>`;
+  }
+  if (e.type === "toolCall") {
+    const args = e.args ? JSON.stringify(e.args, null, 2) : "";
+    return `<details><summary>tool: ${esc(e.tool)}</summary><pre>${esc(args)}</pre></details>`;
+  }
+  if (e.type === "fileRead") {
+    return `<p>read: <code>${esc(e.path)}</code></p>`;
+  }
+  if (e.type === "command") {
+    return `<p>cmd: <code>${esc(e.command)}</code></p>`;
+  }
+  return "";
+}
+
+function renderRunnerBlock(rr: RunnerResult): string {
+  const report = rr.report;
+  const statusLabel = rr.passed ? "PASS" : "FAIL";
+  const runnerId = rr.runner?.id ?? "unknown";
+  const eventsHtml = (report?.events ?? []).map(renderEvent).join("\n");
+  const errorHtml = rr.error
+    ? `<pre>${esc(rr.error.message)}\n${esc(rr.error.stack ?? "")}</pre>`
+    : "";
+  const finalOutput = report?.finalOutput
+    ? `<details><summary>final output</summary><pre>${esc(report.finalOutput)}</pre></details>`
+    : "";
+
+  return `
+    <section>
+      <h3>${esc(runnerId)} — ${statusLabel} — ${ms(rr.durationMs)}
+        &nbsp; in: ${tokens(report?.usage?.inputTokens)} / out: ${tokens(report?.usage?.outputTokens)}
+      </h3>
+      ${errorHtml}
+      ${finalOutput}
+      ${eventsHtml}
+    </section>`;
+}
+
+function renderCaseSection(testCase: Case, caseResult: CaseResult): string {
+  const status = caseResult.passed ? "✓" : "✗";
+  const runnerBlocks = (caseResult.runnerResults ?? [])
+    .filter(Boolean)
+    .map(renderRunnerBlock)
+    .join("\n");
+
+  return `
+    <details>
+      <summary><strong>${status} ${esc(testCase.id)}</strong></summary>
+      <blockquote><pre>${esc(testCase.prompt)}</pre></blockquote>
+      ${runnerBlocks}
+    </details>`;
+}
+
+function renderPage(result: SuiteRunResult, caseSections: string): string {
+  const passed = result.cases.filter((c) => c.passed).length;
+  const total = result.cases.length;
+
+  return `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <title>skillgym — ${esc(result.suitePath)}</title>
+      <style>
+        body { font-family: monospace; margin: 2em; }
+        pre { white-space: pre-wrap; word-break: break-word; background: #f4f4f4; padding: 0.5em; }
+        summary { cursor: pointer; }
+        blockquote { border-left: 3px solid #ccc; margin: 0; padding-left: 1em; }
+        h3 { margin: 0.5em 0; font-size: 1em; }
+        section { margin-left: 1em; border-left: 2px solid #eee; padding-left: 1em; }
+      </style>
+    </head>
+    <body>
+      <h1>skillgym report</h1>
+      <p>${esc(result.suitePath)}</p>
+      <p>${passed}/${total} passed &nbsp; ${ms(result.durationMs)}</p>
+      <hr>
+      ${caseSections}
+    </body>
+    </html>`;
+}
+
+export function createHtmlReporter(): BenchmarkReporter {
+  const caseResults: CaseFinishEvent[] = [];
+
+  return {
+    onCaseFinish(event) {
+      caseResults.push(event);
+    },
+
+    onSuiteFinish(event) {
+      try {
+        const { result } = event;
+        const caseSections = caseResults
+          .map((ev) => renderCaseSection(ev.case, ev.result))
+          .join("\n");
+        const html = renderPage(result, caseSections);
+        const outPath = join(result.suiteRunArtifactDir, "report.html");
+        writeFileSync(outPath, html, "utf-8");
+        console.log(`\nHTML report: ${outPath}\n`);
+      } catch (err) {
+        console.error("html-reporter error:", err);
+      }
+    },
+  };
+}

--- a/src/reporters/index.ts
+++ b/src/reporters/index.ts
@@ -11,6 +11,7 @@ export type {
 } from "./contract.js";
 export { BUILT_IN_REPORTER_NAMES } from "./builtins.js";
 export { createGitHubActionsReporter } from "./github-actions.js";
+export { createHtmlReporter } from "./html.js";
 export { createJsonReporter } from "./json.js";
 export { createJsonSummaryReporter } from "./json-summary.js";
 export { loadReporter } from "./load-reporter.js";

--- a/src/reporters/load-reporter.ts
+++ b/src/reporters/load-reporter.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import type { BenchmarkReporter } from "./contract.js";
 import { createGitHubActionsReporter } from "./github-actions.js";
+import { createHtmlReporter } from "./html.js";
 import { createJsonReporter } from "./json.js";
 import { createJsonSummaryReporter } from "./json-summary.js";
 import { createStandardReporter } from "./standard.js";
@@ -40,6 +41,8 @@ export async function loadReporter(
         return createJsonSummaryReporter();
       case "github-actions":
         return createGitHubActionsReporter();
+      case "html":
+        return createHtmlReporter();
     }
   }
 

--- a/test/reporters/html.test.ts
+++ b/test/reporters/html.test.ts
@@ -1,0 +1,209 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import type { Case } from "../../src/domain/case.js";
+import type { CaseResult, RunnerResult, SuiteRunResult } from "../../src/domain/result.js";
+import type { RunnerInfo } from "../../src/domain/runner.js";
+import type { SessionReport } from "../../src/domain/session-report.js";
+import type { ReporterContext } from "../../src/reporters/contract.js";
+import { createHtmlReporter } from "../../src/reporters/html.js";
+
+const runner: RunnerInfo = {
+  id: "claude-code@sonnet",
+  pathKey: "claude-code",
+  agent: { type: "claude-code", model: "claude-sonnet-4" },
+};
+
+const report: SessionReport = {
+  runner,
+  prompt: "fix the bug",
+  usage: {
+    inputTokens: 1200,
+    outputTokens: 300,
+    inputChars: 0,
+    outputChars: 0,
+    reasoningChars: 0,
+    source: { input: "provider", output: "provider", reasoning: "derived" },
+  },
+  files: { observedReads: [], observedSkillReads: [] },
+  detectedSkills: [],
+  events: [],
+  finalOutput: "I fixed the bug.",
+  rawArtifacts: {},
+};
+
+function makeContext(suiteRunArtifactDir: string): ReporterContext {
+  return {
+    isInteractive: false,
+    cwd: "/workspace",
+    workspaceMode: "shared",
+    suitePath: "examples/basic-suite.ts",
+    suiteRunArtifactDir,
+    selectedCaseCount: 1,
+    selectedRunnerCount: 1,
+    selectedExecutionCount: 1,
+    scheduleMode: "serial",
+    maxParallel: 1,
+    declaredTags: [],
+  };
+}
+
+describe("createHtmlReporter", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "skillgym-html-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("writes report.html to suiteRunArtifactDir with pass counts and case details", async () => {
+    const reporter = createHtmlReporter();
+
+    const runnerResult: RunnerResult = {
+      runner,
+      passed: true,
+      status: "passed",
+      durationMs: 1500,
+      executionArtifactDir: tempDir,
+      artifactDir: tempDir,
+      report,
+    };
+    const caseResult: CaseResult = {
+      caseId: "write-hello",
+      tags: [],
+      passed: true,
+      runnerResults: [runnerResult],
+    };
+    const testCase: Case = {
+      id: "write-hello",
+      prompt: "Write hello world",
+      assert: () => {},
+    };
+    const suiteResult: SuiteRunResult = {
+      suitePath: "examples/basic-suite.ts",
+      startedAt: "2026-04-02T12:00:00.000Z",
+      endedAt: "2026-04-02T12:01:00.000Z",
+      durationMs: 60_000,
+      suiteRunArtifactDir: tempDir,
+      declaredTags: [],
+      selectedTags: [],
+      cases: [caseResult],
+      runners: [],
+    };
+
+    await reporter.onCaseFinish?.({
+      context: makeContext(tempDir),
+      case: testCase,
+      result: caseResult,
+      caseIndex: 0,
+      totalCases: 1,
+    });
+    await reporter.onSuiteFinish?.({
+      context: makeContext(tempDir),
+      result: suiteResult,
+    });
+
+    const html = await readFile(path.join(tempDir, "report.html"), "utf-8");
+    expect(html).toContain("1/1 passed");
+    expect(html).toContain("write-hello");
+    expect(html).toContain("Write hello world");
+    expect(html).toContain("PASS");
+    expect(html).toContain("I fixed the bug.");
+  });
+
+  test("escapes HTML special characters in case id and prompt", async () => {
+    const reporter = createHtmlReporter();
+
+    const maliciousCase: Case = {
+      id: "xss-<script>alert(1)</script>",
+      prompt: 'Prompt with <b>bold</b> & "quotes"',
+      assert: () => {},
+    };
+    const caseResult: CaseResult = {
+      caseId: maliciousCase.id,
+      tags: [],
+      passed: false,
+      runnerResults: [],
+    };
+    const suiteResult: SuiteRunResult = {
+      suitePath: "examples/basic-suite.ts",
+      startedAt: "2026-04-02T12:00:00.000Z",
+      endedAt: "2026-04-02T12:00:05.000Z",
+      durationMs: 5_000,
+      suiteRunArtifactDir: tempDir,
+      declaredTags: [],
+      selectedTags: [],
+      cases: [caseResult],
+      runners: [],
+    };
+
+    await reporter.onCaseFinish?.({
+      context: makeContext(tempDir),
+      case: maliciousCase,
+      result: caseResult,
+      caseIndex: 0,
+      totalCases: 1,
+    });
+    await reporter.onSuiteFinish?.({
+      context: makeContext(tempDir),
+      result: suiteResult,
+    });
+
+    const html = await readFile(path.join(tempDir, "report.html"), "utf-8");
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&lt;b&gt;bold&lt;/b&gt;");
+    expect(html).toContain("&amp;");
+    expect(html).toContain("&quot;quotes&quot;");
+  });
+
+  test("two instances do not share case state", async () => {
+    const reporterA = createHtmlReporter();
+    const reporterB = createHtmlReporter();
+
+    const testCase: Case = {
+      id: "case-only-in-a",
+      prompt: "only reporter A sees this",
+      assert: () => {},
+    };
+    const caseResult: CaseResult = {
+      caseId: testCase.id,
+      tags: [],
+      passed: true,
+      runnerResults: [],
+    };
+
+    await reporterA.onCaseFinish?.({
+      context: makeContext(tempDir),
+      case: testCase,
+      result: caseResult,
+      caseIndex: 0,
+      totalCases: 1,
+    });
+
+    const suiteResult: SuiteRunResult = {
+      suitePath: "examples/basic-suite.ts",
+      startedAt: "2026-04-02T12:00:00.000Z",
+      endedAt: "2026-04-02T12:00:01.000Z",
+      durationMs: 1_000,
+      suiteRunArtifactDir: tempDir,
+      declaredTags: [],
+      selectedTags: [],
+      cases: [],
+      runners: [],
+    };
+
+    // reporterB never saw the case — its HTML should not contain it
+    await reporterB.onSuiteFinish?.({
+      context: makeContext(tempDir),
+      result: suiteResult,
+    });
+
+    const html = await readFile(path.join(tempDir, "report.html"), "utf-8");
+    expect(html).not.toContain("case-only-in-a");
+  });
+});

--- a/test/reporters/load-reporter.test.ts
+++ b/test/reporters/load-reporter.test.ts
@@ -42,6 +42,13 @@ describe("loadReporter", () => {
     expect(reporter.onRunnerFinish).toBeUndefined();
   });
 
+  test("resolves built-in reporter when html is provided", async () => {
+    const reporter = await loadReporter("html", tempDir);
+
+    expect(typeof reporter.onCaseFinish).toBe("function");
+    expect(typeof reporter.onSuiteFinish).toBe("function");
+  });
+
   test("loads custom reporter from relative default export path", async () => {
     const filePath = path.join(tempDir, "default-reporter.ts");
     await writeFile(filePath, "export default { onSuiteStart() {} };\n", "utf8");


### PR DESCRIPTION
## Summary

- Adds `html` as a built-in reporter (`--reporter html`) that writes a self-contained `report.html` to the suite run artifact directory
- Report renders a collapsible tree: suite summary → case → runner execution → session events (assistant messages, tool calls, file reads, commands)
- Exported as `createHtmlReporter()` from the `skillgym` package for programmatic use

## Test plan

- [x] Unit tests for `createHtmlReporter` covering output content, HTML escaping, and instance state isolation
- [x] `loadReporter("html")` resolution test added to `load-reporter.test.ts`
- [x] `docs/reporters.md` updated with CLI example and reporter description

🤖 Generated with [Claude Code](https://claude.com/claude-code)