### PR TITLE
Fix README config example syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Create `skillgym.config.ts` in your project root, or in a parent directory that 
 ```ts
 import type { SkillGymConfig } from "skillgym";
 
-const config: SkillGymConfig = {
+const config = {
   run: {
     cwd: ".",
     outputDir: "./.skillgym-results",
@@ -48,26 +48,26 @@ const config: SkillGymConfig = {
     timeoutMs: 120_000,
   },
   runners: {
-    open-main: {
+    "open-main": {
       agent: {
         type: "opencode",
         model: "openai/gpt-5",
       },
     },
-    code-main: {
+    "code-main": {
       agent: {
         type: "codex",
         model: "gpt-5",
       },
     },
-    cursor-main: {
+    "cursor-main": {
       agent: {
         type: "cursor-agent",
         model: "composer-2-fast",
       },
     },
   },
-};
+} satisfies SkillGymConfig;
 
 export default config;
 ```

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -26,13 +26,13 @@ If both tolerances are configured, exceeding either one fails the execution.
 ```ts
 export default {
   runners: {
-    open-main: {
+    "open-main": {
       agent: {
         type: "opencode",
         model: "openai/gpt-5",
       },
     },
-    code-main: {
+    "code-main": {
       agent: {
         type: "codex",
         model: "gpt-5",

--- a/test/public-api.test.ts
+++ b/test/public-api.test.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, it } from "vitest";
-import type { Case, Suite, TestCase, TestSuite } from "../src/index.js";
+import type { Case, SkillGymConfig, Suite, TestCase, TestSuite } from "../src/index.js";
 
 describe("public API compatibility", () => {
   it("exports TestCase as an alias of Case", () => {
@@ -8,5 +8,11 @@ describe("public API compatibility", () => {
 
   it("exports TestSuite as an alias of Suite", () => {
     expectTypeOf<TestSuite>().toEqualTypeOf<Suite>();
+  });
+
+  it("exports SkillGymConfig from the root public API", () => {
+    expectTypeOf<SkillGymConfig>().toMatchTypeOf<{
+      runners: Record<string, { agent: { type: string; model: string } }>;
+    }>();
   });
 });


### PR DESCRIPTION
## Summary
- fix the README config snippet to use valid TypeScript runner keys and a `satisfies SkillGymConfig` pattern
- update the snapshot docs example with the same quoted runner ids
- add a focused public API test covering the root `SkillGymConfig` export

## Testing
- pnpm exec vitest run test/public-api.test.ts test/config.test.ts
- pnpm typecheck *(fails on pre-existing unrelated test typing errors in `test/config.test.ts`, `test/runner/execute-suite.reporter.test.ts`, `test/runner/model-rejection.test.ts`, and `test/runner/workspace.test.ts`)*