### PR TITLE
Fix public assert typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "typecheck": "tsc -p ./tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@types/node": ">=22.18.0",
     "cli-spinners": "^3.4.0",
     "nano-spawn": "^2.1.0",
     "picocolors": "^1.1.1",
@@ -65,7 +66,6 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.30.0",
-    "@types/node": "^25.6.0",
     "esbuild": "^0.25.3",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@types/node':
+        specifier: '>=22.18.0'
+        version: 25.6.0
       cli-spinners:
         specifier: ^3.4.0
         version: 3.4.0
@@ -30,9 +33,6 @@ importers:
       '@changesets/cli':
         specifier: ^2.30.0
         version: 2.30.0(@types/node@25.6.0)
-      '@types/node':
-        specifier: ^25.6.0
-        version: 25.6.0
       esbuild:
         specifier: ^0.25.3
         version: 0.25.12

--- a/src/assertions/types.ts
+++ b/src/assertions/types.ts
@@ -1,4 +1,4 @@
-type NodeAssert = typeof import("node:assert/strict");
+import type nodeAssert from "node:assert/strict";
 import type { ExplainOptions } from "./explain.js";
 import type { FailureClass } from "../domain/result.js";
 import type { SessionReport, ToolCallEvent } from "../domain/session-report.js";
@@ -162,7 +162,7 @@ export interface AssertionClassifier {
   <T>(failureClass: string | FailureClass, callback: () => T): T;
 }
 
-export type SkillGymSoftAssert = NodeAssert & {
+export type SkillGymSoftAssert = typeof nodeAssert & {
   skills: SkillAssertions;
   commands: CommandAssertions;
   fileReads: FileReadAssertions;
@@ -170,7 +170,7 @@ export type SkillGymSoftAssert = NodeAssert & {
   output: OutputAssertions;
 };
 
-export type SkillGymAssert = NodeAssert & {
+export type SkillGymAssert = typeof nodeAssert & {
   soft: SkillGymSoftAssert;
   skills: SkillAssertions;
   commands: CommandAssertions;

--- a/src/assertions/types.ts
+++ b/src/assertions/types.ts
@@ -1,4 +1,4 @@
-import type nodeAssert from "node:assert/strict";
+type NodeAssert = typeof import("node:assert/strict");
 import type { ExplainOptions } from "./explain.js";
 import type { FailureClass } from "../domain/result.js";
 import type { SessionReport, ToolCallEvent } from "../domain/session-report.js";
@@ -162,7 +162,7 @@ export interface AssertionClassifier {
   <T>(failureClass: string | FailureClass, callback: () => T): T;
 }
 
-export type SkillGymSoftAssert = typeof nodeAssert & {
+export type SkillGymSoftAssert = NodeAssert & {
   skills: SkillAssertions;
   commands: CommandAssertions;
   fileReads: FileReadAssertions;
@@ -170,7 +170,7 @@ export type SkillGymSoftAssert = typeof nodeAssert & {
   output: OutputAssertions;
 };
 
-export type SkillGymAssert = typeof nodeAssert & {
+export type SkillGymAssert = NodeAssert & {
   soft: SkillGymSoftAssert;
   skills: SkillAssertions;
   commands: CommandAssertions;

--- a/test/fixtures/public-assert-types/input.mts
+++ b/test/fixtures/public-assert-types/input.mts
@@ -1,0 +1,11 @@
+import { assert } from "skillgym";
+
+assert.equal(1, 1);
+assert.commands.includes(null as never, "pnpm test");
+
+// @ts-expect-error matcher should stay strongly typed
+assert.commands.includes(null as never, 123);
+
+// This must stay type-checked from the package export, not collapse to any.
+// @ts-expect-error assert should not expose unknown methods
+assert.notARealMethod();

--- a/test/fixtures/public-assert-types/tsconfig.json
+++ b/test/fixtures/public-assert-types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "target": "ESNext",
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["./input.mts"]
+}


### PR DESCRIPTION
## Summary
- replace the public `assert` type aliasing from a default `node:assert/strict` import with `typeof import(...)` so consumers keep the full Node assert surface instead of degrading to `any`
- add a focused consumer-style TypeScript fixture that typechecks the built package export and guards both core `assert` methods and custom SkillGym assertion helpers

## Testing
- `pnpm exec vitest run test/public-api.test.ts`
- `pnpm exec tsc -p ./tsconfig.build.json && pnpm exec tsc -p ./test/fixtures/public-assert-types/tsconfig.json`