### PR TITLE
Allow shared workspace bootstrap setup

### DIFF
--- a/DICTIONARY.md
+++ b/DICTIONARY.md
@@ -31,8 +31,8 @@ Before adding or changing a term, check this file and ask the user for approval.
 - `workspace`: Directory where the agent runs.
 - `shared workspace`: Run directly in one real directory.
 - `isolated workspace`: Fresh workspace created per execution.
-- `workspace template`: Directory copied into an isolated workspace before execution.
-- `workspace bootstrap`: Command run in an isolated workspace before the agent starts.
+- `workspace template`: Directory copied into an execution workspace before execution.
+- `workspace bootstrap`: Command run in an execution workspace before the agent starts.
 - `schedule`: Execution ordering and concurrency policy.
 - `reporter`: Component rendering suite-run progress and results.
 - `skill detection`: Evidence that a skill was used, with confidence and evidence.

--- a/DICTIONARY.md
+++ b/DICTIONARY.md
@@ -29,10 +29,11 @@ Before adding or changing a term, check this file and ask the user for approval.
 - `artifact`: Preserved file or directory written by SkillGym.
 - `artifact directory`: Directory holding artifacts for one scope such as a suite run, execution, repetition, retry, or session.
 - `workspace`: Directory where the agent runs.
-- `shared workspace`: Run directly in one real directory.
+- `no workspace`: Run directly in an existing working directory with no provisioning.
+- `shared workspace`: One provisioned workspace created once per suite run and reused across executions.
 - `isolated workspace`: Fresh workspace created per execution.
 - `workspace template`: Directory copied into an execution workspace before execution.
-- `workspace bootstrap`: Command run in an execution workspace before the agent starts.
+- `workspace bootstrap`: Command run in a provisioned workspace before the agent starts.
 - `schedule`: Execution ordering and concurrency policy.
 - `reporter`: Component rendering suite-run progress and results.
 - `skill detection`: Evidence that a skill was used, with confidence and evidence.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ A workspace is the directory where an execution runs.
 - `shared`: run directly in one real directory
 - `isolated`: create a fresh temporary workspace per case x runner execution
 
-Use `shared` when you want the agent to work against your real project checkout. Use `isolated` when you want clean filesystem state per execution or need to prepare each execution from a template.
+Use `shared` when you want the agent to work against your real project checkout. Shared mode can still seed that directory with `templateDir` and `bootstrap` before the agent starts. Use `isolated` when you want clean filesystem state per execution or need a fresh prepared workspace every time.
 
 You can configure workspaces in `skillgym.config.*` with `run.workspace`, or per suite with a named `workspace` export. Suite-level workspace config overrides config-level `run.workspace`.
 

--- a/docs/cases.md
+++ b/docs/cases.md
@@ -249,6 +249,13 @@ export type SuiteWorkspaceConfig =
   | {
       mode: "shared";
       cwd?: string;
+      templateDir?: string;
+      bootstrap?: {
+        command: string;
+        args?: string[];
+        timeoutMs?: number;
+        env?: Record<string, string>;
+      };
     }
   | {
       mode: "isolated";
@@ -264,8 +271,8 @@ export type SuiteWorkspaceConfig =
 
 Rules:
 
-- `shared` mode supports `cwd` only
-- `isolated` mode supports `templateDir` and `bootstrap` only
+- `shared` mode supports `cwd`, `templateDir`, and `bootstrap`
+- `isolated` mode supports `templateDir` and `bootstrap` but not `cwd`
 - relative suite workspace paths resolve from the suite file directory
 - isolated workspaces start empty when `templateDir` is omitted
 - `templateDir` copies the full directory contents, including dotfiles and `.git`

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -94,7 +94,6 @@ export const workspace = {
 
 Bootstrap command behavior:
 
-- `cwd` is the isolated workspace
 - `cwd` is the shared workspace or isolated workspace for that execution
 - non-zero exit fails that execution before the agent runs
 - stdout and stderr are written to the execution artifact directory
@@ -122,7 +121,7 @@ Path rules:
 
 - config `run.workspace` paths resolve from the config file directory
 - suite `workspace` paths resolve from the suite file directory
-- `bootstrap.command` and path-like `bootstrap.args` are resolved from the config or suite directory before the bootstrap runs inside the isolated workspace
+- `bootstrap.command` and path-like `bootstrap.args` are resolved from the config or suite directory before the bootstrap runs inside the execution workspace
 
 ## Limitations
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -58,7 +58,8 @@ Behavior:
 - executions run directly in the shared directory
 - `cwd` is optional
 - if omitted, shared mode falls back to config `run.cwd`, then `process.cwd()`
-- `templateDir` and `bootstrap` are not allowed
+- `templateDir` copies into the shared directory before the agent starts
+- `bootstrap` runs inside the shared directory before the agent starts
 
 ## Isolated mode
 
@@ -79,11 +80,11 @@ Behavior:
 
 ## Bootstrap commands
 
-Bootstrap commands run inside the isolated workspace before the agent starts.
+Bootstrap commands run inside the execution workspace before the agent starts.
 
 ```ts
 export const workspace = {
-  mode: "isolated",
+  mode: "shared",
   bootstrap: {
     command: "sh",
     args: ["./scripts/bootstrap-workspace.sh", "--seed", "demo"],
@@ -94,6 +95,7 @@ export const workspace = {
 Bootstrap command behavior:
 
 - `cwd` is the isolated workspace
+- `cwd` is the shared workspace or isolated workspace for that execution
 - non-zero exit fails that execution before the agent runs
 - stdout and stderr are written to the execution artifact directory
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -2,12 +2,13 @@
 
 ## Overview
 
-`skillgym` supports two workspace modes:
+`skillgym` supports three workspace modes:
 
-- `shared`: run directly in a real working directory
+- `none`: run directly in an existing working directory
+- `shared`: create one workspace per suite run and reuse it across executions
 - `isolated`: create a fresh workspace per case x runner execution
 
-Use isolated workspaces when suites need different filesystem setups or when executions should not mutate the original source tree.
+Use `none` when the agent should run in an existing directory. Use `shared` or `isolated` when the suite needs SkillGym to provision a workspace first.
 
 ## Suite-level workspace config
 
@@ -44,22 +45,42 @@ Suite workspace config overrides config-level `run.workspace`.
 
 See `../examples/workspace-isolation-suite.ts` for a complete example that copies a template directory and runs a bootstrap command before the agent starts.
 
-## Shared mode
+## None mode
 
 ```ts
 export const workspace = {
-  mode: "shared",
+  mode: "none",
   cwd: "./fixtures/repo-a",
 };
 ```
 
 Behavior:
 
-- executions run directly in the shared directory
+- executions run directly in `cwd`
 - `cwd` is optional
-- if omitted, shared mode falls back to config `run.cwd`, then `process.cwd()`
-- `templateDir` copies into the shared directory before the agent starts
-- `bootstrap` runs inside the shared directory before the agent starts
+- if omitted, none mode falls back to config `run.cwd`, then `process.cwd()`
+- `templateDir` and `bootstrap` are not allowed
+
+If a suite file does not export `workspace`, SkillGym falls back to config `run.workspace`, then to implicit `none` mode.
+
+## Shared mode
+
+```ts
+export const workspace = {
+  mode: "shared",
+  templateDir: "./fixtures/repo-template",
+};
+```
+
+Behavior:
+
+- one shared workspace is created under `outputDir/workspaces/shared`
+- all executions reuse that same workspace for the suite run
+- `cwd` is not allowed
+- `templateDir` copies into the shared workspace before any execution starts
+- `bootstrap` runs once inside the shared workspace before any execution starts
+- successful suite runs delete the shared workspace
+- failed suite runs preserve the shared workspace
 
 ## Isolated mode
 
@@ -94,22 +115,28 @@ export const workspace = {
 
 Bootstrap command behavior:
 
-- `cwd` is the shared workspace or isolated workspace for that execution
+- `cwd` is the provisioned shared workspace or isolated workspace
 - non-zero exit fails that execution before the agent runs
-- stdout and stderr are written to the execution artifact directory
+- shared-workspace bootstrap stdout and stderr are written to `outputDir/workspaces/shared-setup`
+- isolated-workspace bootstrap stdout and stderr are written to the execution artifact directory
 
 Runtime environment variables:
 
 - `SKILLGYM_WORKSPACE`
-- `SKILLGYM_CASE_ID`
-- `SKILLGYM_RUNNER_ID`
 - `SKILLGYM_OUTPUT_DIR`
 - `SKILLGYM_ARTIFACT_DIR`
+
+Isolated workspace bootstrap also receives:
+
+- `SKILLGYM_CASE_ID`
+- `SKILLGYM_RUNNER_ID`
 
 ## Cleanup
 
 Cleanup behavior is fixed:
 
+- successful shared suite runs delete their workspace
+- failed shared suite runs preserve their workspace
 - successful isolated executions delete their workspace
 - failed isolated executions preserve their workspace
 

--- a/skills/workspaces.md
+++ b/skills/workspaces.md
@@ -20,6 +20,11 @@ Use isolated workspaces when executions should not mutate the original checkout 
 export const workspace = {
   mode: "shared",
   cwd: "./fixtures/repo-a",
+  templateDir: "./fixtures/base-project",
+  bootstrap: {
+    command: "sh",
+    args: ["./scripts/bootstrap-workspace.sh"],
+  },
 };
 ```
 
@@ -28,6 +33,8 @@ Behavior:
 - executions run directly in that directory
 - `cwd` is optional
 - if omitted, Skillgym falls back to config `run.cwd`, then `process.cwd()`
+- `templateDir` copies into that directory before the agent starts
+- `bootstrap` runs in that directory before the agent starts
 
 ## Isolated mode
 

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -63,9 +63,9 @@ export async function runCommand(options: {
     suiteDir: suite.dirPath,
   });
 
-  if (options.cwd !== undefined && effectiveWorkspace.mode === "isolated") {
+  if (options.cwd !== undefined && effectiveWorkspace.mode !== "none") {
     throw new Error(
-      "CLI option --cwd is only supported when the effective workspace mode is shared.",
+      "CLI option --cwd is only supported when the effective workspace mode is none.",
     );
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -421,10 +421,37 @@ function parseWorkspaceConfig(value: unknown, configPath: string): SuiteWorkspac
   const templateDir = parseOptionalNonEmptyString(record.templateDir, `${configPath}.templateDir`);
   const bootstrap = parseOptionalBootstrapConfig(record.bootstrap, `${configPath}.bootstrap`);
 
-  if (mode === "shared") {
+  if (mode === "none") {
+    if (templateDir !== undefined) {
+      throw invalidConfig(
+        `${configPath}.templateDir`,
+        'expected this key to be omitted when workspace mode is "none"',
+      );
+    }
+
+    if (bootstrap !== undefined) {
+      throw invalidConfig(
+        `${configPath}.bootstrap`,
+        'expected this key to be omitted when workspace mode is "none"',
+      );
+    }
+
     return {
       mode,
       cwd,
+    };
+  }
+
+  if (mode === "shared") {
+    if (cwd !== undefined) {
+      throw invalidConfig(
+        `${configPath}.cwd`,
+        'expected this key to be omitted when workspace mode is "shared"',
+      );
+    }
+
+    return {
+      mode,
       templateDir,
       bootstrap,
     };
@@ -445,8 +472,8 @@ function parseWorkspaceConfig(value: unknown, configPath: string): SuiteWorkspac
 }
 
 function parseWorkspaceMode(value: unknown, configPath: string): SuiteWorkspaceConfig["mode"] {
-  if (value !== "shared" && value !== "isolated") {
-    throw invalidConfig(configPath, 'expected "shared" or "isolated"');
+  if (value !== "none" && value !== "shared" && value !== "isolated") {
+    throw invalidConfig(configPath, 'expected "none", "shared", or "isolated"');
   }
 
   return value;
@@ -611,10 +638,16 @@ function resolveWorkspaceConfigPaths(
   config: SuiteWorkspaceConfig,
   configDir: string,
 ): SuiteWorkspaceConfig {
+  if (config.mode === "none") {
+    return {
+      mode: "none",
+      cwd: config.cwd === undefined ? undefined : path.resolve(configDir, config.cwd),
+    };
+  }
+
   if (config.mode === "shared") {
     return {
       mode: "shared",
-      cwd: config.cwd === undefined ? undefined : path.resolve(configDir, config.cwd),
       templateDir:
         config.templateDir === undefined ? undefined : path.resolve(configDir, config.templateDir),
       bootstrap:

--- a/src/config.ts
+++ b/src/config.ts
@@ -422,23 +422,11 @@ function parseWorkspaceConfig(value: unknown, configPath: string): SuiteWorkspac
   const bootstrap = parseOptionalBootstrapConfig(record.bootstrap, `${configPath}.bootstrap`);
 
   if (mode === "shared") {
-    if (templateDir !== undefined) {
-      throw invalidConfig(
-        `${configPath}.templateDir`,
-        'expected this key to be omitted when workspace mode is "shared"',
-      );
-    }
-
-    if (bootstrap !== undefined) {
-      throw invalidConfig(
-        `${configPath}.bootstrap`,
-        'expected this key to be omitted when workspace mode is "shared"',
-      );
-    }
-
     return {
       mode,
       cwd,
+      templateDir,
+      bootstrap,
     };
   }
 
@@ -627,6 +615,12 @@ function resolveWorkspaceConfigPaths(
     return {
       mode: "shared",
       cwd: config.cwd === undefined ? undefined : path.resolve(configDir, config.cwd),
+      templateDir:
+        config.templateDir === undefined ? undefined : path.resolve(configDir, config.templateDir),
+      bootstrap:
+        config.bootstrap === undefined
+          ? undefined
+          : resolveBootstrapConfigPaths(config.bootstrap, configDir),
     };
   }
 

--- a/src/domain/case.ts
+++ b/src/domain/case.ts
@@ -12,8 +12,8 @@ export type SuiteWorkspaceConfig =
   | {
       mode: "shared";
       cwd?: string;
-      templateDir?: never;
-      bootstrap?: never;
+      templateDir?: string;
+      bootstrap?: WorkspaceBootstrapConfig;
     }
   | {
       mode: "isolated";

--- a/src/domain/case.ts
+++ b/src/domain/case.ts
@@ -10,8 +10,14 @@ export interface WorkspaceBootstrapConfig {
 
 export type SuiteWorkspaceConfig =
   | {
-      mode: "shared";
+      mode: "none";
       cwd?: string;
+      templateDir?: never;
+      bootstrap?: never;
+    }
+  | {
+      mode: "shared";
+      cwd?: never;
       templateDir?: string;
       bootstrap?: WorkspaceBootstrapConfig;
     }

--- a/src/reporters/contract.ts
+++ b/src/reporters/contract.ts
@@ -6,7 +6,7 @@ import type { Case } from "../domain/case.js";
 export interface ReporterContext {
   isInteractive: boolean;
   cwd: string;
-  workspaceMode: "shared" | "isolated";
+  workspaceMode: "none" | "shared" | "isolated";
   suitePath: string;
   suiteRunArtifactDir: string;
   selectedCaseCount: number;

--- a/src/reporters/standard.ts
+++ b/src/reporters/standard.ts
@@ -105,10 +105,13 @@ export function createStandardReporter(options: StandardReporterOptions = {}): B
     onSuiteStart(event) {
       printBanner({ kind: "compact", stdout });
       writeLine(`${colors.dim("Suite     ")}${accent(event.context.suitePath)}`, stdout);
-      writeLine(
-        `${colors.dim("Workspace ")}${colors.bold(event.context.workspaceMode === "shared" ? event.context.cwd : `${event.context.workspaceMode} per execution`)}`,
-        stdout,
-      );
+      const workspaceLabel =
+        event.context.workspaceMode === "shared"
+          ? event.context.cwd
+          : event.context.workspaceMode === "isolated"
+            ? "isolated per execution"
+            : `${event.context.cwd} (none)`;
+      writeLine(`${colors.dim("Workspace ")}${colors.bold(workspaceLabel)}`, stdout);
       writeLine(`${colors.dim("Cases     ")}${String(event.context.selectedCaseCount)}`, stdout);
       if (event.context.tagFilter !== undefined) {
         writeLine(`${colors.dim("Tags      ")}${event.context.tagFilter.join(", ")}`, stdout);

--- a/src/runner/execute-suite.ts
+++ b/src/runner/execute-suite.ts
@@ -26,8 +26,11 @@ import { scheduleExecutions, type PlannedExecution } from "./scheduler.js";
 import {
   createExecutionFailureResult,
   finalizeWorkspace,
+  getSharedWorkspacePath,
   prepareWorkspace,
+  prepareSharedWorkspace,
   resolveEffectiveWorkspace,
+  writeExecutionWorkspaceMetadata,
 } from "./workspace.js";
 
 interface PlannedSuiteExecution {
@@ -54,6 +57,7 @@ export async function executeSuite(
   options: {
     cwd: string;
     outputDir?: string;
+    suiteRunArtifactDir?: string;
     schedule?: ScheduleMode;
     maxParallel?: number;
     repeat?: number;
@@ -86,7 +90,10 @@ export async function executeSuite(
   const startedAt = nowIso();
   const startedMs = Date.now();
   const resolvedSuitePath = path.resolve(suitePath);
-  const outputDir = path.resolve(options.outputDir ?? ".skillgym-results", timestampDirName());
+  const outputDir =
+    options.suiteRunArtifactDir === undefined
+      ? path.resolve(options.outputDir ?? ".skillgym-results", timestampDirName())
+      : path.resolve(options.suiteRunArtifactDir);
   const scheduleMode = options.schedule ?? "serial";
   const maxParallel = resolveMaxParallel(scheduleMode, options.maxParallel);
   const repeat = options.repeat ?? options.config.run?.repeat ?? 1;
@@ -123,7 +130,7 @@ export async function executeSuite(
     );
     await options.reporter?.onError?.({
       context: createReporterContext({
-        cwd: resolvedWorkspace.mode === "shared" ? resolvedWorkspace.cwd : options.cwd,
+        cwd: resolveReporterWorkspaceCwd(resolvedWorkspace, outputDir),
         suitePath: resolvedSuitePath,
         outputDir,
         selectedCases,
@@ -147,7 +154,7 @@ export async function executeSuite(
     const error = new Error("No cases matched the requested filters.");
     await options.reporter?.onError?.({
       context: createReporterContext({
-        cwd: resolvedWorkspace.mode === "shared" ? resolvedWorkspace.cwd : options.cwd,
+        cwd: resolveReporterWorkspaceCwd(resolvedWorkspace, outputDir),
         suitePath: resolvedSuitePath,
         outputDir,
         selectedCases,
@@ -168,7 +175,7 @@ export async function executeSuite(
   }
 
   const context = createReporterContext({
-    cwd: resolvedWorkspace.mode === "shared" ? resolvedWorkspace.cwd : options.cwd,
+    cwd: resolveReporterWorkspaceCwd(resolvedWorkspace, outputDir),
     suitePath: resolvedSuitePath,
     outputDir,
     selectedCases,
@@ -190,6 +197,16 @@ export async function executeSuite(
   const caseStates = createPlannedCaseStates(selectedCases.length);
   const rejectedRunners = new Map<string, RunnerResult>();
   const restoreMaxListeners = raiseProcessMaxListeners(resolveProcessMaxListeners(maxParallel));
+  const sharedWorkspace =
+    resolvedWorkspace.mode === "shared"
+      ? createSharedWorkspaceState(resolvedWorkspace, {
+          outputDir,
+          timeoutMs: plannedExecutions.reduce(
+            (maxTimeoutMs, execution) => Math.max(maxTimeoutMs, execution.item.timeoutMs),
+            120_000,
+          ),
+        })
+      : undefined;
 
   try {
     await options.reporter?.onSuiteStart?.({
@@ -198,6 +215,10 @@ export async function executeSuite(
       runners: selectedRunners.map((runner) => runner.info),
       startedAt,
     });
+
+    if (sharedWorkspace !== undefined) {
+      await sharedWorkspace.prepare();
+    }
 
     const initialExecutions = plannedExecutions.filter(
       (execution) => execution.item.caseIndex === 0,
@@ -221,6 +242,7 @@ export async function executeSuite(
         maxSteps: options.config.run?.maxSteps,
         repeat,
         repeatFailure,
+        sharedWorkspace,
         reporter: options.reporter,
         rejectedRunners,
       });
@@ -241,6 +263,7 @@ export async function executeSuite(
         maxSteps: options.config.run?.maxSteps,
         repeat,
         repeatFailure,
+        sharedWorkspace,
         reporter: options.reporter,
         rejectedRunners,
       });
@@ -267,6 +290,9 @@ export async function executeSuite(
 
     await writeJson(path.join(outputDir, "results.json"), result);
     await snapshotStore?.save();
+    if (sharedWorkspace !== undefined) {
+      await sharedWorkspace.finalize(result.cases.every((caseResult) => caseResult.passed));
+    }
     await options.reporter?.onSuiteFinish?.({ context, result });
     return result;
   } catch (error) {
@@ -362,6 +388,7 @@ async function executePlannedExecution(
     maxSteps?: number;
     repeat: number;
     repeatFailure: number;
+    sharedWorkspace?: SharedWorkspaceState;
     reporter?: BenchmarkReporter;
     rejectedRunners: Map<string, RunnerResult>;
   },
@@ -423,6 +450,7 @@ async function executePlannedExecution(
               executeRunnerFn: options.executeRunnerFn,
               outputDir: options.outputDir,
               maxSteps: options.maxSteps,
+              sharedWorkspace: options.sharedWorkspace,
             })
           : await createRejectedModelResult(item, sessionArtifactDir);
 
@@ -542,6 +570,7 @@ async function runExecution(
     executeRunnerFn: typeof executeRunner;
     outputDir: string;
     maxSteps?: number;
+    sharedWorkspace?: SharedWorkspaceState;
   },
 ): Promise<RunnerResult> {
   const executionStartedMs = Date.now();
@@ -549,13 +578,16 @@ async function runExecution(
   let preparedWorkspace;
 
   try {
-    preparedWorkspace = await prepareWorkspace(options.resolvedWorkspace, {
-      artifactDir: options.artifactDir,
-      outputDir: options.outputDir,
-      case: item.case,
-      runner: item.runner.info,
-      timeoutMs: item.timeoutMs,
-    });
+    preparedWorkspace =
+      options.sharedWorkspace === undefined
+        ? await prepareWorkspace(options.resolvedWorkspace, {
+            artifactDir: options.artifactDir,
+            outputDir: options.outputDir,
+            case: item.case,
+            runner: item.runner.info,
+            timeoutMs: item.timeoutMs,
+          })
+        : await options.sharedWorkspace.createExecutionWorkspace(options.artifactDir);
 
     result = await options.executeRunnerFn(
       item.case,
@@ -585,10 +617,22 @@ async function runExecution(
     await writeJson(path.join(options.artifactDir, "report.json"), result.report);
   } finally {
     if (preparedWorkspace !== undefined) {
-      await finalizeWorkspace(preparedWorkspace, {
-        artifactDir: options.artifactDir,
-        passed: result!.passed,
-      });
+      if (preparedWorkspace.mode === "shared") {
+        await writeExecutionWorkspaceMetadata(path.join(options.artifactDir, "workspace.json"), {
+          mode: "shared",
+          cwd: preparedWorkspace.cwd,
+          templateDir: preparedWorkspace.templateDir,
+          workspacePath: preparedWorkspace.workspacePath,
+          bootstrap: preparedWorkspace.bootstrap,
+          preserved: false,
+          cleanupError: undefined,
+        });
+      } else {
+        await finalizeWorkspace(preparedWorkspace, {
+          artifactDir: options.artifactDir,
+          passed: result!.passed,
+        });
+      }
     }
   }
 
@@ -973,7 +1017,7 @@ function createPlannedCaseStates(caseCount: number): PlannedCaseState[] {
 
 function createReporterContext(options: {
   cwd: string;
-  workspaceMode: "shared" | "isolated";
+  workspaceMode: "none" | "shared" | "isolated";
   suitePath: string;
   outputDir: string;
   selectedCases: Case[];
@@ -1004,6 +1048,66 @@ function createReporterContext(options: {
     tagFilter: options.tagFilter.length === 0 ? undefined : options.tagFilter,
     declaredTags: options.declaredTags,
   };
+}
+
+interface SharedWorkspaceState {
+  prepare(): Promise<void>;
+  createExecutionWorkspace(
+    artifactDir: string,
+  ): Promise<Awaited<ReturnType<typeof prepareSharedWorkspace>>>;
+  finalize(passed: boolean): Promise<void>;
+}
+
+function createSharedWorkspaceState(
+  config: ReturnType<typeof resolveEffectiveWorkspace>,
+  options: {
+    outputDir: string;
+    timeoutMs: number;
+  },
+): SharedWorkspaceState {
+  const setupArtifactDir = path.join(options.outputDir, "workspaces", "shared-setup");
+  let preparedPromise: Promise<Awaited<ReturnType<typeof prepareSharedWorkspace>>> | undefined;
+
+  const loadPreparedWorkspace = () => {
+    preparedPromise ??= (async () => {
+      await ensureDir(setupArtifactDir);
+      return prepareSharedWorkspace(config, {
+        outputDir: options.outputDir,
+        artifactDir: setupArtifactDir,
+        timeoutMs: options.timeoutMs,
+      });
+    })();
+
+    return preparedPromise;
+  };
+
+  return {
+    async prepare() {
+      await loadPreparedWorkspace();
+    },
+    async createExecutionWorkspace() {
+      return loadPreparedWorkspace();
+    },
+    async finalize(passed) {
+      if (!passed) {
+        return;
+      }
+
+      const preparedWorkspace = await loadPreparedWorkspace();
+      await preparedWorkspace.cleanup();
+    },
+  };
+}
+
+function resolveReporterWorkspaceCwd(
+  resolvedWorkspace: ReturnType<typeof resolveEffectiveWorkspace>,
+  outputDir: string,
+): string {
+  if (resolvedWorkspace.mode === "shared") {
+    return getSharedWorkspacePath(outputDir);
+  }
+
+  return resolvedWorkspace.mode === "none" ? resolvedWorkspace.cwd : outputDir;
 }
 
 function resolveMaxParallel(

--- a/src/runner/workspace.ts
+++ b/src/runner/workspace.ts
@@ -17,7 +17,7 @@ import {
 import { execFileCapture } from "../utils/process.js";
 
 export interface ResolvedWorkspaceConfig {
-  mode: "shared" | "isolated";
+  mode: "none" | "shared" | "isolated";
   cwd: string;
   templateDir?: string;
   bootstrap?: WorkspaceBootstrapConfig;
@@ -49,11 +49,17 @@ interface BootstrapResult {
 
 export interface PreparedWorkspace {
   cwd: string;
-  mode: "shared" | "isolated";
+  mode: "none" | "shared" | "isolated";
   workspacePath?: string;
   templateDir?: string;
   bootstrap?: BootstrapResult;
   cleanup(): Promise<{ preserved: boolean; cleanupError?: string }>;
+}
+
+export interface SharedWorkspaceSetupOptions {
+  outputDir: string;
+  artifactDir: string;
+  timeoutMs: number;
 }
 
 export function resolveEffectiveWorkspace(options: WorkspaceSetupOptions): ResolvedWorkspaceConfig {
@@ -66,15 +72,22 @@ export function resolveEffectiveWorkspace(options: WorkspaceSetupOptions): Resol
 
   if (effective === undefined) {
     return {
-      mode: "shared",
+      mode: "none",
       cwd: options.baseCwd,
+    };
+  }
+
+  if (effective.mode === "none") {
+    return {
+      mode: "none",
+      cwd: effective.cwd ?? options.baseCwd,
     };
   }
 
   if (effective.mode === "shared") {
     return {
       mode: "shared",
-      cwd: effective.cwd ?? options.baseCwd,
+      cwd: "",
       templateDir: effective.templateDir,
       bootstrap: effective.bootstrap,
     };
@@ -92,7 +105,29 @@ export function validateSuiteWorkspaceConfig(
   config: SuiteWorkspaceConfig,
   configPath = "workspace",
 ): void {
+  if (config.mode === "none") {
+    if (config.templateDir !== undefined) {
+      throw new Error(
+        `Invalid suite config at ${configPath}.templateDir: expected this key to be omitted when workspace mode is "none"`,
+      );
+    }
+
+    if (config.bootstrap !== undefined) {
+      throw new Error(
+        `Invalid suite config at ${configPath}.bootstrap: expected this key to be omitted when workspace mode is "none"`,
+      );
+    }
+
+    return;
+  }
+
   if (config.mode === "shared") {
+    if (config.cwd !== undefined) {
+      throw new Error(
+        `Invalid suite config at ${configPath}.cwd: expected this key to be omitted when workspace mode is "shared"`,
+      );
+    }
+
     return;
   }
 
@@ -107,39 +142,28 @@ export async function prepareWorkspace(
   config: ResolvedWorkspaceConfig,
   options: ExecutionWorkspaceOptions,
 ): Promise<PreparedWorkspace> {
-  if (config.mode === "shared") {
-    let bootstrap: BootstrapResult | undefined;
-
-    if (config.templateDir !== undefined) {
-      await ensureDirectoryExists(config.templateDir);
-      await ensureDir(config.cwd);
-      await copyDir(config.templateDir, config.cwd);
-    }
-
-    bootstrap =
-      config.bootstrap === undefined
-        ? undefined
-        : await runBootstrap(config.bootstrap, config.cwd, options);
-
+  if (config.mode === "none") {
     await writeWorkspaceMetadata(path.join(options.artifactDir, "workspace.json"), {
-      mode: "shared",
+      mode: "none",
       cwd: config.cwd,
-      templateDir: config.templateDir,
+      templateDir: undefined,
       workspacePath: undefined,
-      bootstrap,
+      bootstrap: undefined,
       preserved: false,
       cleanupError: undefined,
     });
 
     return {
       cwd: config.cwd,
-      mode: "shared",
-      templateDir: config.templateDir,
-      bootstrap,
+      mode: "none",
       async cleanup() {
         return { preserved: false };
       },
     };
+  }
+
+  if (config.mode === "shared") {
+    throw new Error("Shared workspaces must be prepared once per suite run.");
   }
 
   const workspacePath = path.join(
@@ -209,7 +233,7 @@ export async function finalizeWorkspace(
     passed: boolean;
   },
 ): Promise<void> {
-  if (prepared.mode === "shared") {
+  if (prepared.mode === "none" || prepared.mode === "shared") {
     return;
   }
 
@@ -226,6 +250,92 @@ export async function finalizeWorkspace(
     preserved: cleanupResult.preserved,
     cleanupError: cleanupResult.cleanupError,
   });
+}
+
+export async function prepareSharedWorkspace(
+  config: ResolvedWorkspaceConfig,
+  options: SharedWorkspaceSetupOptions,
+): Promise<PreparedWorkspace> {
+  if (config.mode !== "shared") {
+    throw new Error(`Expected shared workspace config, received ${config.mode}`);
+  }
+
+  const workspacePath = getSharedWorkspacePath(options.outputDir);
+  let bootstrap: BootstrapResult | undefined;
+
+  try {
+    await removeDir(workspacePath);
+
+    if (config.templateDir !== undefined) {
+      await ensureDirectoryExists(config.templateDir);
+      await copyDir(config.templateDir, workspacePath);
+    } else {
+      await ensureDir(workspacePath);
+    }
+
+    bootstrap =
+      config.bootstrap === undefined
+        ? undefined
+        : await runBootstrap(config.bootstrap, workspacePath, {
+            artifactDir: options.artifactDir,
+            outputDir: options.outputDir,
+            timeoutMs: options.timeoutMs,
+          });
+
+    await writeWorkspaceMetadata(path.join(options.artifactDir, "workspace.json"), {
+      mode: "shared",
+      cwd: workspacePath,
+      templateDir: config.templateDir,
+      workspacePath,
+      bootstrap,
+      preserved: false,
+      cleanupError: undefined,
+    });
+
+    return {
+      cwd: workspacePath,
+      mode: "shared",
+      workspacePath,
+      templateDir: config.templateDir,
+      bootstrap,
+      async cleanup() {
+        return cleanupWorkspace({
+          artifactDir: options.artifactDir,
+          workspacePath,
+        });
+      },
+    };
+  } catch (error) {
+    await writeWorkspaceMetadata(path.join(options.artifactDir, "workspace.json"), {
+      mode: "shared",
+      cwd: workspacePath,
+      templateDir: config.templateDir,
+      workspacePath,
+      bootstrap,
+      preserved: true,
+      cleanupError: serializeError(error).message,
+    });
+    throw error;
+  }
+}
+
+export async function writeExecutionWorkspaceMetadata(
+  filePath: string,
+  value: {
+    mode: "none" | "shared" | "isolated";
+    cwd: string;
+    templateDir?: string;
+    workspacePath?: string;
+    bootstrap?: BootstrapResult;
+    preserved: boolean;
+    cleanupError?: string;
+  },
+): Promise<void> {
+  await writeWorkspaceMetadata(filePath, value);
+}
+
+export function getSharedWorkspacePath(outputDir: string): string {
+  return path.join(outputDir, "workspaces", "shared");
 }
 
 export function createExecutionFailureResult(
@@ -292,10 +402,16 @@ function resolveSuiteWorkspacePaths(
   config: SuiteWorkspaceConfig,
   suiteDir: string,
 ): SuiteWorkspaceConfig {
+  if (config.mode === "none") {
+    return {
+      mode: "none",
+      cwd: config.cwd === undefined ? undefined : path.resolve(suiteDir, config.cwd),
+    };
+  }
+
   if (config.mode === "shared") {
     return {
       mode: "shared",
-      cwd: config.cwd === undefined ? undefined : path.resolve(suiteDir, config.cwd),
       templateDir:
         config.templateDir === undefined ? undefined : path.resolve(suiteDir, config.templateDir),
       bootstrap:
@@ -329,7 +445,10 @@ function resolveSuiteWorkspacePaths(
 async function runBootstrap(
   config: WorkspaceBootstrapConfig,
   workspacePath: string,
-  options: ExecutionWorkspaceOptions,
+  options: Pick<ExecutionWorkspaceOptions, "artifactDir" | "outputDir" | "timeoutMs"> & {
+    case?: Pick<Case, "id">;
+    runner?: Pick<RunnerInfo, "id">;
+  },
 ): Promise<BootstrapResult> {
   const stdoutPath = path.join(options.artifactDir, "bootstrap.stdout.log");
   const stderrPath = path.join(options.artifactDir, "bootstrap.stderr.log");
@@ -342,8 +461,8 @@ async function runBootstrap(
       ...process.env,
       ...config.env,
       SKILLGYM_WORKSPACE: workspacePath,
-      SKILLGYM_CASE_ID: options.case.id,
-      SKILLGYM_RUNNER_ID: options.runner.id,
+      ...(options.case === undefined ? {} : { SKILLGYM_CASE_ID: options.case.id }),
+      ...(options.runner === undefined ? {} : { SKILLGYM_RUNNER_ID: options.runner.id }),
       SKILLGYM_OUTPUT_DIR: options.outputDir,
       SKILLGYM_ARTIFACT_DIR: options.artifactDir,
     },
@@ -390,7 +509,7 @@ async function cleanupWorkspace(options: {
 async function writeWorkspaceMetadata(
   filePath: string,
   value: {
-    mode: "shared" | "isolated";
+    mode: "none" | "shared" | "isolated";
     cwd: string;
     templateDir?: string;
     workspacePath?: string;

--- a/src/runner/workspace.ts
+++ b/src/runner/workspace.ts
@@ -75,6 +75,8 @@ export function resolveEffectiveWorkspace(options: WorkspaceSetupOptions): Resol
     return {
       mode: "shared",
       cwd: effective.cwd ?? options.baseCwd,
+      templateDir: effective.templateDir,
+      bootstrap: effective.bootstrap,
     };
   }
 
@@ -91,18 +93,6 @@ export function validateSuiteWorkspaceConfig(
   configPath = "workspace",
 ): void {
   if (config.mode === "shared") {
-    if (config.templateDir !== undefined) {
-      throw new Error(
-        `Invalid suite config at ${configPath}.templateDir: expected this key to be omitted when workspace mode is "shared"`,
-      );
-    }
-
-    if (config.bootstrap !== undefined) {
-      throw new Error(
-        `Invalid suite config at ${configPath}.bootstrap: expected this key to be omitted when workspace mode is "shared"`,
-      );
-    }
-
     return;
   }
 
@@ -118,12 +108,25 @@ export async function prepareWorkspace(
   options: ExecutionWorkspaceOptions,
 ): Promise<PreparedWorkspace> {
   if (config.mode === "shared") {
+    let bootstrap: BootstrapResult | undefined;
+
+    if (config.templateDir !== undefined) {
+      await ensureDirectoryExists(config.templateDir);
+      await ensureDir(config.cwd);
+      await copyDir(config.templateDir, config.cwd);
+    }
+
+    bootstrap =
+      config.bootstrap === undefined
+        ? undefined
+        : await runBootstrap(config.bootstrap, config.cwd, options);
+
     await writeWorkspaceMetadata(path.join(options.artifactDir, "workspace.json"), {
       mode: "shared",
       cwd: config.cwd,
-      templateDir: undefined,
+      templateDir: config.templateDir,
       workspacePath: undefined,
-      bootstrap: undefined,
+      bootstrap,
       preserved: false,
       cleanupError: undefined,
     });
@@ -131,6 +134,8 @@ export async function prepareWorkspace(
     return {
       cwd: config.cwd,
       mode: "shared",
+      templateDir: config.templateDir,
+      bootstrap,
       async cleanup() {
         return { preserved: false };
       },
@@ -291,6 +296,17 @@ function resolveSuiteWorkspacePaths(
     return {
       mode: "shared",
       cwd: config.cwd === undefined ? undefined : path.resolve(suiteDir, config.cwd),
+      templateDir:
+        config.templateDir === undefined ? undefined : path.resolve(suiteDir, config.templateDir),
+      bootstrap:
+        config.bootstrap === undefined
+          ? undefined
+          : {
+              command: resolvePathLikeValue(config.bootstrap.command, suiteDir),
+              args: config.bootstrap.args?.map((arg) => resolvePathLikeValue(arg, suiteDir)),
+              timeoutMs: config.bootstrap.timeoutMs,
+              env: config.bootstrap.env === undefined ? undefined : { ...config.bootstrap.env },
+            },
     };
   }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -466,7 +466,7 @@ test("cli run exits non-zero for assertion failures without printing a generic s
     })),
   }));
   vi.doMock("../src/runner/workspace.js", () => ({
-    resolveEffectiveWorkspace: vi.fn(() => ({ mode: "shared", cwd: tempDir })),
+    resolveEffectiveWorkspace: vi.fn(() => ({ mode: "none", cwd: tempDir })),
   }));
   vi.doMock("../src/runner/execute-suite.js", () => ({
     executeSuite: vi.fn(async () => ({
@@ -592,7 +592,7 @@ async function importRunCommandWithSuiteResult(tempDir: string, suiteResult: unk
     })),
   }));
   vi.doMock("../src/runner/workspace.js", () => ({
-    resolveEffectiveWorkspace: vi.fn(() => ({ mode: "shared", cwd: tempDir })),
+    resolveEffectiveWorkspace: vi.fn(() => ({ mode: "none", cwd: tempDir })),
   }));
   vi.doMock("../src/runner/execute-suite.js", () => ({
     executeSuite: vi.fn(async () => suiteResult),
@@ -664,7 +664,7 @@ test("cli run passes repeated and comma-separated tag filters to execution", asy
     })),
   }));
   vi.doMock("../src/runner/workspace.js", () => ({
-    resolveEffectiveWorkspace: vi.fn(() => ({ mode: "shared", cwd: tempDir })),
+    resolveEffectiveWorkspace: vi.fn(() => ({ mode: "none", cwd: tempDir })),
   }));
   vi.doMock("../src/runner/execute-suite.js", () => ({ executeSuite }));
 
@@ -742,7 +742,7 @@ test("cli run passes retryFailed through to execution", async () => {
     })),
   }));
   vi.doMock("../src/runner/workspace.js", () => ({
-    resolveEffectiveWorkspace: vi.fn(() => ({ mode: "shared", cwd: tempDir })),
+    resolveEffectiveWorkspace: vi.fn(() => ({ mode: "none", cwd: tempDir })),
   }));
   vi.doMock("../src/runner/execute-suite.js", () => ({
     executeSuite,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -178,14 +178,6 @@ describe("config", () => {
     ).toThrow("Invalid config at runners.openMain.agent.model: expected non-empty string");
     expect(() =>
       parseConfig({
-        run: { workspace: { mode: "shared", templateDir: "./fixture" } },
-        runners: { openMain: { agent: { type: "opencode", model: "openai/gpt-5" } } },
-      }),
-    ).toThrow(
-      'Invalid config at run.workspace.templateDir: expected this key to be omitted when workspace mode is "shared"',
-    );
-    expect(() =>
-      parseConfig({
         snapshots: { tolerance: {} },
         runners: { openMain: { agent: { type: "opencode", model: "openai/gpt-5" } } },
       }),
@@ -227,6 +219,69 @@ describe("config", () => {
         runners: { open: { agent: { type: "opencode", model: "openai/gpt-5" } } },
       }).run?.schedule,
     ).toBe("isolated-by-runner");
+  });
+
+  test("parses shared workspace template and bootstrap config", () => {
+    expect(
+      parseConfig({
+        run: {
+          workspace: {
+            mode: "shared",
+            cwd: "./workspace",
+            templateDir: "./fixture",
+            bootstrap: {
+              command: "./scripts/bootstrap.sh",
+              args: ["./scripts/seed.ts", "--flag"],
+              timeoutMs: 5000,
+              env: { NODE_ENV: "test" },
+            },
+          },
+        },
+        runners: { openMain: { agent: { type: "opencode", model: "openai/gpt-5" } } },
+      }).run?.workspace,
+    ).toEqual({
+      mode: "shared",
+      cwd: "./workspace",
+      templateDir: "./fixture",
+      bootstrap: {
+        command: "./scripts/bootstrap.sh",
+        args: ["./scripts/seed.ts", "--flag"],
+        timeoutMs: 5000,
+        env: { NODE_ENV: "test" },
+      },
+    });
+  });
+
+  test("resolves shared workspace template and bootstrap paths from config directory", async () => {
+    const suiteDir = path.join(tempDir, "bench", "nested");
+    await mkdir(suiteDir, { recursive: true });
+    await writeFile(path.join(suiteDir, "suite.ts"), "export default []\n", "utf8");
+    await writeFile(
+      path.join(tempDir, "bench", "skillgym.config.mjs"),
+      [
+        "export default {",
+        "  run: { workspace: { mode: 'shared', cwd: './workspace', templateDir: './fixtures/base', bootstrap: { command: './scripts/bootstrap.sh', args: ['./scripts/seed.ts', '--flag'], timeoutMs: 5000 } } },",
+        "  runners: {",
+        "    openMain: { agent: { type: 'opencode', model: 'openai/gpt-5' } }",
+        "  }",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const loaded = await loadConfig({ suitePath: path.join(suiteDir, "suite.ts") });
+
+    expect(loaded.config.run?.workspace).toEqual({
+      mode: "shared",
+      cwd: path.join(tempDir, "bench", "workspace"),
+      templateDir: path.join(tempDir, "bench", "fixtures", "base"),
+      bootstrap: {
+        command: path.join(tempDir, "bench", "scripts", "bootstrap.sh"),
+        args: [path.join(tempDir, "bench", "scripts", "seed.ts"), "--flag"],
+        timeoutMs: 5000,
+      },
+    });
   });
 
   test("parses run maxSteps", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -227,7 +227,6 @@ describe("config", () => {
         run: {
           workspace: {
             mode: "shared",
-            cwd: "./workspace",
             templateDir: "./fixture",
             bootstrap: {
               command: "./scripts/bootstrap.sh",
@@ -241,7 +240,6 @@ describe("config", () => {
       }).run?.workspace,
     ).toEqual({
       mode: "shared",
-      cwd: "./workspace",
       templateDir: "./fixture",
       bootstrap: {
         command: "./scripts/bootstrap.sh",
@@ -260,7 +258,7 @@ describe("config", () => {
       path.join(tempDir, "bench", "skillgym.config.mjs"),
       [
         "export default {",
-        "  run: { workspace: { mode: 'shared', cwd: './workspace', templateDir: './fixtures/base', bootstrap: { command: './scripts/bootstrap.sh', args: ['./scripts/seed.ts', '--flag'], timeoutMs: 5000 } } },",
+        "  run: { workspace: { mode: 'shared', templateDir: './fixtures/base', bootstrap: { command: './scripts/bootstrap.sh', args: ['./scripts/seed.ts', '--flag'], timeoutMs: 5000 } } },",
         "  runners: {",
         "    openMain: { agent: { type: 'opencode', model: 'openai/gpt-5' } }",
         "  }",
@@ -274,7 +272,6 @@ describe("config", () => {
 
     expect(loaded.config.run?.workspace).toEqual({
       mode: "shared",
-      cwd: path.join(tempDir, "bench", "workspace"),
       templateDir: path.join(tempDir, "bench", "fixtures", "base"),
       bootstrap: {
         command: path.join(tempDir, "bench", "scripts", "bootstrap.sh"),
@@ -282,6 +279,53 @@ describe("config", () => {
         timeoutMs: 5000,
       },
     });
+  });
+
+  test("parses none workspace with cwd", () => {
+    expect(
+      parseConfig({
+        run: {
+          workspace: {
+            mode: "none",
+            cwd: "./workspace",
+          },
+        },
+        runners: { openMain: { agent: { type: "opencode", model: "openai/gpt-5" } } },
+      }).run?.workspace,
+    ).toEqual({
+      mode: "none",
+      cwd: "./workspace",
+    });
+  });
+
+  test("rejects invalid workspace keys by mode", () => {
+    expect(() =>
+      parseConfig({
+        run: {
+          workspace: {
+            mode: "shared",
+            cwd: "./workspace",
+          },
+        },
+        runners: { openMain: { agent: { type: "opencode", model: "openai/gpt-5" } } },
+      }),
+    ).toThrow(
+      'Invalid config at run.workspace.cwd: expected this key to be omitted when workspace mode is "shared"',
+    );
+
+    expect(() =>
+      parseConfig({
+        run: {
+          workspace: {
+            mode: "none",
+            templateDir: "./fixture",
+          },
+        },
+        runners: { openMain: { agent: { type: "opencode", model: "openai/gpt-5" } } },
+      }),
+    ).toThrow(
+      'Invalid config at run.workspace.templateDir: expected this key to be omitted when workspace mode is "none"',
+    );
   });
 
   test("parses run maxSteps", () => {

--- a/test/runner/workspace.test.ts
+++ b/test/runner/workspace.test.ts
@@ -96,7 +96,6 @@ test("executeSuite provisions isolated workspaces from suite template and remove
 test("executeSuite provisions shared workspace from template and bootstrap before runner starts", async () => {
   const tempDir = await createTempDir();
   const suiteRunArtifactDir = path.join(tempDir, "results");
-  const sharedWorkspaceDir = path.join(tempDir, "shared-workspace");
   const templateDir = path.join(tempDir, "template");
   const suiteDir = path.join(tempDir, "suite-dir");
   const scriptPath = path.join(suiteDir, "bootstrap.sh");
@@ -106,20 +105,29 @@ test("executeSuite provisions shared workspace from template and bootstrap befor
   await writeFile(path.join(templateDir, "README.md"), "template\n", "utf8");
   await writeFile(
     scriptPath,
-    "#!/bin/sh\nprintf 'Bootstrap marker: shared\\n' > bootstrap-output.txt\n",
+    [
+      "#!/bin/sh",
+      "printf 'Bootstrap marker: shared\\n' > bootstrap-output.txt",
+      "count=$(cat bootstrap-count.txt 2>/dev/null || printf '0')",
+      "printf '%s' $((count + 1)) > bootstrap-count.txt",
+      "",
+    ].join("\n"),
     "utf8",
   );
 
   const runner = createRunnerInfo("open", { type: "opencode", model: "openai/gpt-5" });
+  const seenCwds: string[] = [];
   const result = await executeSuite(
     path.join(suiteDir, "suite.ts"),
-    [{ id: "alpha", prompt: "hello", assert() {} }],
+    [
+      { id: "alpha", prompt: "hello", assert() {} },
+      { id: "beta", prompt: "hello", assert() {} },
+    ],
     {
       cwd: tempDir,
       suiteRunArtifactDir,
       suiteWorkspace: {
         mode: "shared",
-        cwd: sharedWorkspaceDir,
         templateDir,
         bootstrap: {
           command: "sh",
@@ -132,11 +140,12 @@ test("executeSuite provisions shared workspace from template and bootstrap befor
         },
       },
       executeRunnerFn: async (_case, _runner, _adapter, options) => {
-        expect(options.cwd).toBe(sharedWorkspaceDir);
+        seenCwds.push(options.cwd);
         expect(await readFile(path.join(options.cwd, "README.md"), "utf8")).toBe("template\n");
         expect(await readFile(path.join(options.cwd, "bootstrap-output.txt"), "utf8")).toContain(
           "shared",
         );
+        expect(await readFile(path.join(options.cwd, "bootstrap-count.txt"), "utf8")).toBe("1");
 
         return {
           runner,
@@ -152,7 +161,10 @@ test("executeSuite provisions shared workspace from template and bootstrap befor
   );
 
   expect(result.cases[0]?.passed).toBe(true);
-  expect((await stat(sharedWorkspaceDir)).isDirectory()).toBe(true);
+  expect(result.cases[1]?.passed).toBe(true);
+  expect(new Set(seenCwds).size).toBe(1);
+  const sharedWorkspaceDir = seenCwds[0]!;
+  await expect(stat(sharedWorkspaceDir)).rejects.toThrow();
 
   const executionArtifactDir = path.join(
     result.suiteRunArtifactDir,
@@ -164,12 +176,53 @@ test("executeSuite provisions shared workspace from template and bootstrap befor
     path.join(executionArtifactDir, "workspace.json"),
     "utf8",
   );
-  const stdout = await readFile(path.join(executionArtifactDir, "bootstrap.stdout.log"), "utf8");
+  const stdout = await readFile(
+    path.join(result.suiteRunArtifactDir, "workspaces", "shared-setup", "bootstrap.stdout.log"),
+    "utf8",
+  );
 
   expect(workspaceMetadata).toContain('"mode": "shared"');
   expect(workspaceMetadata).toContain(JSON.stringify(sharedWorkspaceDir));
   expect(workspaceMetadata).toContain(JSON.stringify(templateDir));
   expect(stdout).toBe("");
+});
+
+test("executeSuite defaults to none workspace when config and suite omit workspace", async () => {
+  const tempDir = await createTempDir();
+  const suiteRunArtifactDir = path.join(tempDir, "results");
+  const runner = createRunnerInfo("open", { type: "opencode", model: "openai/gpt-5" });
+  const seenCwds: string[] = [];
+
+  const result = await executeSuite("./suite.ts", [{ id: "alpha", prompt: "hello", assert() {} }], {
+    cwd: tempDir,
+    suiteRunArtifactDir,
+    config: {
+      runners: {
+        open: { agent: { type: "opencode", model: "openai/gpt-5" } },
+      },
+    },
+    executeRunnerFn: async (_case, _runner, _adapter, options) => {
+      seenCwds.push(options.cwd);
+      return {
+        runner,
+        passed: true,
+        status: "passed",
+        durationMs: 10,
+        executionArtifactDir: options.artifactDir,
+        artifactDir: options.artifactDir,
+        report: createSessionReport({ runner, prompt: "hello" }),
+      };
+    },
+  });
+
+  expect(result.cases[0]?.passed).toBe(true);
+  expect(seenCwds).toEqual([tempDir]);
+  expect(
+    await readFile(
+      path.join(result.suiteRunArtifactDir, "alpha", runner.pathKey, "repeat-1", "workspace.json"),
+      "utf8",
+    ),
+  ).toContain('"mode": "none"');
 });
 
 test("executeSuite preserves failed isolated workspaces and writes bootstrap logs", async () => {

--- a/test/runner/workspace.test.ts
+++ b/test/runner/workspace.test.ts
@@ -93,6 +93,85 @@ test("executeSuite provisions isolated workspaces from suite template and remove
   expect(workspaceMetadata).toContain('"preserved": false');
 });
 
+test("executeSuite provisions shared workspace from template and bootstrap before runner starts", async () => {
+  const tempDir = await createTempDir();
+  const suiteRunArtifactDir = path.join(tempDir, "results");
+  const sharedWorkspaceDir = path.join(tempDir, "shared-workspace");
+  const templateDir = path.join(tempDir, "template");
+  const suiteDir = path.join(tempDir, "suite-dir");
+  const scriptPath = path.join(suiteDir, "bootstrap.sh");
+
+  await mkdir(templateDir, { recursive: true });
+  await mkdir(suiteDir, { recursive: true });
+  await writeFile(path.join(templateDir, "README.md"), "template\n", "utf8");
+  await writeFile(
+    scriptPath,
+    "#!/bin/sh\nprintf 'Bootstrap marker: shared\\n' > bootstrap-output.txt\n",
+    "utf8",
+  );
+
+  const runner = createRunnerInfo("open", { type: "opencode", model: "openai/gpt-5" });
+  const result = await executeSuite(
+    path.join(suiteDir, "suite.ts"),
+    [{ id: "alpha", prompt: "hello", assert() {} }],
+    {
+      cwd: tempDir,
+      suiteRunArtifactDir,
+      suiteWorkspace: {
+        mode: "shared",
+        cwd: sharedWorkspaceDir,
+        templateDir,
+        bootstrap: {
+          command: "sh",
+          args: ["./bootstrap.sh"],
+        },
+      },
+      config: {
+        runners: {
+          open: { agent: { type: "opencode", model: "openai/gpt-5" } },
+        },
+      },
+      executeRunnerFn: async (_case, _runner, _adapter, options) => {
+        expect(options.cwd).toBe(sharedWorkspaceDir);
+        expect(await readFile(path.join(options.cwd, "README.md"), "utf8")).toBe("template\n");
+        expect(await readFile(path.join(options.cwd, "bootstrap-output.txt"), "utf8")).toContain(
+          "shared",
+        );
+
+        return {
+          runner,
+          passed: true,
+          status: "passed",
+          durationMs: 10,
+          executionArtifactDir: options.artifactDir,
+          artifactDir: options.artifactDir,
+          report: createSessionReport({ runner, prompt: "hello" }),
+        };
+      },
+    },
+  );
+
+  expect(result.cases[0]?.passed).toBe(true);
+  expect((await stat(sharedWorkspaceDir)).isDirectory()).toBe(true);
+
+  const executionArtifactDir = path.join(
+    result.suiteRunArtifactDir,
+    "alpha",
+    runner.pathKey,
+    "repeat-1",
+  );
+  const workspaceMetadata = await readFile(
+    path.join(executionArtifactDir, "workspace.json"),
+    "utf8",
+  );
+  const stdout = await readFile(path.join(executionArtifactDir, "bootstrap.stdout.log"), "utf8");
+
+  expect(workspaceMetadata).toContain('"mode": "shared"');
+  expect(workspaceMetadata).toContain(JSON.stringify(sharedWorkspaceDir));
+  expect(workspaceMetadata).toContain(JSON.stringify(templateDir));
+  expect(stdout).toBe("");
+});
+
 test("executeSuite preserves failed isolated workspaces and writes bootstrap logs", async () => {
   const tempDir = await createTempDir();
   const suiteRunArtifactDir = path.join(tempDir, "results");


### PR DESCRIPTION
## Summary
- allow shared workspace config to use `templateDir` and `bootstrap`, with the same path resolution rules already used for isolated workspaces
- provision shared workspaces before each execution by copying template contents into the shared directory and running bootstrap with the existing artifact logging and failure handling
- document the new shared workspace behavior and cover it with focused config and workspace unit tests

## Testing
- `pnpm vitest run test/config.test.ts test/runner/workspace.test.ts`