### PR TITLE
fix: externalize packages in CLI bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "build": "npm run build:runtime && npm run build:declarations",
     "build:declarations": "tsc -p ./tsconfig.build.json",
-    "build:runtime": "esbuild ./src/index.ts ./src/cli.ts --bundle --platform=node --format=esm --target=node22 --outdir=./dist",
+    "build:runtime": "esbuild ./src/index.ts ./src/cli.ts --bundle --packages=external --platform=node --format=esm --target=node22 --outdir=./dist",
     "fmt": "oxfmt .",
     "fmt:check": "oxfmt --check .",
     "prepare": "husky",
@@ -52,7 +52,7 @@
     "skillgym:help": "tsx ./index.ts help",
     "skillgym:example:basic": "tsx ./index.ts run ./examples/basic-suite.ts",
     "skillgym:example:skill-selection": "tsx ./index.ts run ./examples/skill-selection-suite.ts",
-    "test": "vitest run",
+    "test": "npm run build:runtime && vitest run",
     "typecheck": "tsc -p ./tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -7,7 +7,6 @@ import { execFileCapture } from "../src/utils/process.js";
 import { accumulateTagOptionValues, parseTagOption } from "../src/cli/tag-options.js";
 
 const repoRoot = process.cwd();
-const tsxLoaderPath = path.join(repoRoot, "node_modules", "tsx", "dist", "loader.mjs");
 const tempDirs: string[] = [];
 
 afterEach(async () => {
@@ -880,12 +879,8 @@ test("cli run passes retryFailed through to execution", async () => {
 });
 
 async function execCli(args: string[], cwd = repoRoot) {
-  return execFileCapture(
-    process.execPath,
-    ["--import", tsxLoaderPath, path.join(repoRoot, "index.ts"), ...args],
-    {
-      cwd,
-      timeoutMs: 30_000,
-    },
-  );
+  return execFileCapture(process.execPath, [path.join(repoRoot, "bin.js"), ...args], {
+    cwd,
+    timeoutMs: 30_000,
+  });
 }

--- a/test/runner/execute-suite.reporter.test.ts
+++ b/test/runner/execute-suite.reporter.test.ts
@@ -1483,6 +1483,8 @@ test("executeSuite raises process max listeners for parallel runs and restores i
           passed: true,
           durationMs: 10,
           executionArtifactDir: options.artifactDir,
+          outputTokens: 0,
+          observedReads: 0,
         });
       },
     });

--- a/test/runner/model-rejection.test.ts
+++ b/test/runner/model-rejection.test.ts
@@ -102,6 +102,7 @@ async function createResultWithLogs(options: {
     passed: false,
     status: "failed",
     durationMs: 1,
+    executionArtifactDir: artifactDir,
     artifactDir,
     error: {
       name: "Error",


### PR DESCRIPTION
## What is this?

This PR fixes the published Skillgym CLI startup path so `npx skillgym ...` can load on modern Node versions without crashing on Commander internals. The issue showed up as `Dynamic require of "node:events" is not supported` before the CLI could run.

## How does it work?

The runtime build now tells esbuild to keep package dependencies external instead of embedding them into the ESM bundle. That lets Node resolve dependencies such as Commander through their package exports at runtime, rather than executing bundled CommonJS `require()` calls inside Skillgym's ESM artifact.

The CLI tests now execute the package bin entrypoint, which imports the generated `dist/cli.js`, so the test suite covers the same path users hit through the installed binary. A couple of stale test fixtures were also updated to match the current runner result shape.

## Why is this useful?

This prevents dependency packaging details from breaking the CLI at startup, especially for CommonJS packages that rely on Node built-ins. It also gives the test suite a direct guard against regressions in the published binary path, so future source-level CLI changes are checked against the artifact users actually run.

Closes #45